### PR TITLE
fix: missing keyword for customConfig

### DIFF
--- a/vector/rke2values.yaml
+++ b/vector/rke2values.yaml
@@ -298,6 +298,7 @@ customConfig:
       type: file
       include:
         - /var/run/cilium/tetragon/tetragon.log
+  sinks:
     redpanda:
       type: kafka
       inputs:


### PR DESCRIPTION
This causes the Vector DaemonSet to crash on startup.

Fixes #15

Signed-off-by: Pip Oomen <pepijn@redpill-linpro.com>
