### PR TITLE
fix: remove not existing targets from kind Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ honey-signal: baseline-signal redpanda-connect-mongo
 
 ##@ remove all honeycluster instrumentation from k8s
 .PHONY: honey-down
-honey-down: traces-off redpanda-topic-delete sc-delete stop-local-port-forwarding  wipe
+honey-down: traces-off redpanda-topic-delete wipe
 
 .PHONY: wipe
 wipe: 


### PR DESCRIPTION
Remove sc-delete and stop-local-port-forwarding targets, as those rules do not exist in Makefile.