### PR TITLE
175 Add STIX Conversion for PixieETL HTTP and DNS Tables

### DIFF
--- a/analysis/hive_sentinel/src/etl/controller.py
+++ b/analysis/hive_sentinel/src/etl/controller.py
@@ -36,6 +36,11 @@ http_columns = [
     'resp_body',
     'resp_body_size',
     'latency',
+    'pod_name',
+    'namespace',
+    'container_id',
+    'pid',
+    'node_name',
 ]
 
 # Columns for DNS_EVENTS
@@ -53,6 +58,11 @@ dns_columns = [
     'resp_header',
     'resp_body',
     'latency',
+    'pod_name',
+    'namespace',
+    'container_id',
+    'pid',
+    'node_name',
 ]
 
 @pixie_bp.route('/start', methods=['POST'])

--- a/analysis/hive_sentinel/src/etl/controller.py
+++ b/analysis/hive_sentinel/src/etl/controller.py
@@ -82,9 +82,11 @@ def start_pixie_etl():
             else:
                 return jsonify({"status": "error", "message": "Invalid timestamp type, must be string or int"}), 400
 
+        if tablename == "http_events":
             etl = PixieETL(
                 table_name='http_events',
                 processed_table='http_events',
+                stix_table='http_stix',
                 column_names=http_columns,
                 poll_interval=poll_interval
             )
@@ -93,6 +95,7 @@ def start_pixie_etl():
             etl = PixieETL(
                 table_name='dns_events',
                 processed_table='dns_events',
+                stix_table='dns_stix',
                 column_names=dns_columns,
                 poll_interval=poll_interval
             )

--- a/analysis/hive_sentinel/src/etl/pixie_etl.py
+++ b/analysis/hive_sentinel/src/etl/pixie_etl.py
@@ -105,7 +105,7 @@ px.display(df, "{self.table_name}")
 
                 for row in rows:
                     all_stix_objects, stix_bundles = transform_pixie_logs_to_stix([row], self.stix_table)
-                    self.client.insert(self.stix_table, [[row.get("time_", 0), json.dumps(stix_bundles)]], column_names=["timestamp", "data"])
+                    self.client.insert(self.stix_table, [[row.get("time_", 0), json.dumps(stix_bundles, default=lambda o: o.decode(errors="replace") if isinstance(o, bytes) else str(o))]], column_names=["timestamp", "data"])
 
                 # Update last_seen_ns
                 self.last_seen_ns = max(int(row.get('time_', 0)) for row in rows if 'time_' in row)

--- a/analysis/hive_sentinel/src/stix/pixie/orchestrator.py
+++ b/analysis/hive_sentinel/src/stix/pixie/orchestrator.py
@@ -1,0 +1,28 @@
+from src.stix.core import sanitize_bundle, generate_stix_id
+from src.stix.pixie.transform_dns_to_stix import transform_dns_row_to_stix
+from src.stix.pixie.transform_http_to_stix import transform_http_row_to_stix
+
+def transform_pixie_logs_to_stix(pixie_logs, log_type):
+    stix_bundles = []
+    all_stix_objects = []
+
+    for log in pixie_logs:
+        if log_type == "dns_stix":
+            stix_objects = transform_dns_row_to_stix(log)
+        elif log_type == "http_stix":
+            stix_objects = transform_http_row_to_stix(log)
+        else:
+            continue
+
+        all_stix_objects.extend(stix_objects)
+
+        stix_bundle = {
+            "type": "bundle",
+            "id": generate_stix_id("bundle"),
+            "spec_version": "2.1",
+            "objects": stix_objects,
+        }
+
+        stix_bundles.append(sanitize_bundle(stix_bundle))
+
+    return all_stix_objects, stix_bundles

--- a/analysis/hive_sentinel/src/stix/pixie/transform_dns_to_stix.py
+++ b/analysis/hive_sentinel/src/stix/pixie/transform_dns_to_stix.py
@@ -1,5 +1,9 @@
 import json
-from src.stix.core import generate_stix_id, _get_current_time_iso_format
+from src.stix.core import (
+    generate_stix_id,
+    _get_current_time_iso_format,
+    generate_unique_log_id,
+)
 
 def transform_dns_row_to_stix(row):
     timestamp = _get_current_time_iso_format()
@@ -20,7 +24,13 @@ def transform_dns_row_to_stix(row):
     src_port = row.get("remote_port")
     dst_port = row.get("local_port")
 
-    corr_id = f"dns-{src_ip or 'unknown'}-{query_name or 'unknown'}-{row.get('time_', '0')}"
+    pid = row.get("pid")
+    container_id = row.get("container_id")
+    pod_name = row.get("pod_name")
+    namespace = row.get("namespace")
+    node_name = row.get("node_name")
+    
+    corr_id = generate_unique_log_id(container_id, pid, node_name, timestamp, "dns_events")
 
     stix_objects = []
 
@@ -30,6 +40,11 @@ def transform_dns_row_to_stix(row):
         "protocols": ["udp"],
         "extensions": {
             "x-pixie-dns-ext": {
+                "pid": pid,
+                "container_id": container_id,
+                "pod_name": pod_name,
+                "namespace": namespace,
+                "node_name": node_name,
                 "query_name": query_name,
                 "query_type": query_type,
                 "response_code": response_code,

--- a/analysis/hive_sentinel/src/stix/pixie/transform_dns_to_stix.py
+++ b/analysis/hive_sentinel/src/stix/pixie/transform_dns_to_stix.py
@@ -1,0 +1,46 @@
+from src.stix.core import generate_stix_id, _get_current_time_iso_format
+
+def transform_dns_row_to_stix(row):
+    timestamp = _get_current_time_iso_format()
+    corr_id = f"dns-{row.get('src_ip', 'unknown')}-{row.get('query_name', 'unknown')}-{row.get('timestamp', '0')}"
+
+    stix_objects = []
+
+    # NetworkTraffic with DNS extension
+    network_traffic_object = {
+        "type": "network-traffic",
+        "id": generate_stix_id("network-traffic"),
+        "protocols": ["udp"],
+        "extensions": {
+            "x-pixie-dns-ext": {
+                "query_name": row.get("query_name"),
+                "query_type": row.get("query_type"),
+                "response_code": row.get("response_code"),
+                "answers": row.get("answers", []),
+                "src_ip": row.get("src_ip"),
+                "dst_ip": row.get("dst_ip"),
+                "src_port": row.get("src_port"),
+                "dst_port": row.get("dst_port"),
+                "raw_row": row,
+            }
+        },
+        "start": timestamp,
+    }
+    stix_objects.append(network_traffic_object)
+
+    observed_data_object = {
+        "type": "observed-data",
+        "id": generate_stix_id("observed-data"),
+        "created_time": timestamp,
+        "first_observed": timestamp,
+        "last_observed": timestamp,
+        "number_observed": 1,
+        "object_refs": [network_traffic_object["id"]],
+        "extensions": {
+            "correlation": corr_id,
+            "note": "Pixie DNS data wrapped in STIX observed-data"
+        },
+    }
+    stix_objects.append(observed_data_object)
+
+    return stix_objects

--- a/analysis/hive_sentinel/src/stix/pixie/transform_http_to_stix.py
+++ b/analysis/hive_sentinel/src/stix/pixie/transform_http_to_stix.py
@@ -1,5 +1,9 @@
 import json
-from src.stix.core import generate_stix_id, _get_current_time_iso_format
+from src.stix.core import (
+    generate_stix_id,
+    _get_current_time_iso_format,
+    generate_unique_log_id,
+)
 
 def transform_http_row_to_stix(row):
     timestamp = _get_current_time_iso_format()
@@ -18,7 +22,13 @@ def transform_http_row_to_stix(row):
     src_ip = row.get("remote_addr")
     src_port = row.get("remote_port")
 
-    corr_id = f"http-{src_ip or 'unknown'}-{path or 'unknown'}-{row.get('time_', '0')}"
+    pid = row.get("pid")
+    container_id = row.get("container_id")
+    pod_name = row.get("pod_name")
+    namespace = row.get("namespace")
+    node_name = row.get("node_name")
+
+    corr_id = generate_unique_log_id(container_id, pid, node_name, timestamp, "http_events")
 
     stix_objects = []
 
@@ -28,6 +38,11 @@ def transform_http_row_to_stix(row):
         "protocols": ["tcp"],
         "extensions": {
             "x-pixie-http-ext": {
+                "pid": pid,
+                "container_id": container_id,
+                "pod_name": pod_name,
+                "namespace": namespace,
+                "node_name": node_name,
                 "method": method,
                 "url": url,
                 "status_code": status_code,

--- a/analysis/hive_sentinel/src/stix/pixie/transform_http_to_stix.py
+++ b/analysis/hive_sentinel/src/stix/pixie/transform_http_to_stix.py
@@ -1,27 +1,42 @@
+import json
 from src.stix.core import generate_stix_id, _get_current_time_iso_format
 
 def transform_http_row_to_stix(row):
     timestamp = _get_current_time_iso_format()
-    corr_id = f"http-{row.get('src_ip', 'unknown')}-{row.get('url', 'unknown')}-{row.get('timestamp', '0')}"
+
+    req_headers = json.loads(row.get("req_headers", "{}"))
+    resp_headers = json.loads(row.get("resp_headers", "{}"))
+
+    method = row.get("req_method")
+    path = row.get("req_path")
+    status_code = row.get("resp_status")
+
+    dst_ip = row.get("local_addr")
+    dst_port = row.get("local_port")
+    url = f"http://{dst_ip}:{dst_port}{path}" if dst_ip and dst_port and path else None
+
+    src_ip = row.get("remote_addr")
+    src_port = row.get("remote_port")
+
+    corr_id = f"http-{src_ip or 'unknown'}-{path or 'unknown'}-{row.get('time_', '0')}"
 
     stix_objects = []
 
-    # NetworkTraffic with HTTP extension
     network_traffic_object = {
         "type": "network-traffic",
         "id": generate_stix_id("network-traffic"),
         "protocols": ["tcp"],
         "extensions": {
             "x-pixie-http-ext": {
-                "method": row.get("method"),
-                "url": row.get("url"),
-                "status_code": row.get("status_code"),
-                "headers": row.get("headers", {}),
-                "src_ip": row.get("src_ip"),
-                "dst_ip": row.get("dst_ip"),
-                "src_port": row.get("src_port"),
-                "dst_port": row.get("dst_port"),
-                "raw_row": row,
+                "method": method,
+                "url": url,
+                "status_code": status_code,
+                "headers": req_headers,
+                "src_ip": src_ip,
+                "dst_ip": dst_ip,
+                "src_port": src_port,
+                "dst_port": dst_port,
+                "raw_row": row, 
             }
         },
         "start": timestamp,

--- a/analysis/hive_sentinel/src/stix/pixie/transform_http_to_stix.py
+++ b/analysis/hive_sentinel/src/stix/pixie/transform_http_to_stix.py
@@ -1,0 +1,46 @@
+from src.stix.core import generate_stix_id, _get_current_time_iso_format
+
+def transform_http_row_to_stix(row):
+    timestamp = _get_current_time_iso_format()
+    corr_id = f"http-{row.get('src_ip', 'unknown')}-{row.get('url', 'unknown')}-{row.get('timestamp', '0')}"
+
+    stix_objects = []
+
+    # NetworkTraffic with HTTP extension
+    network_traffic_object = {
+        "type": "network-traffic",
+        "id": generate_stix_id("network-traffic"),
+        "protocols": ["tcp"],
+        "extensions": {
+            "x-pixie-http-ext": {
+                "method": row.get("method"),
+                "url": row.get("url"),
+                "status_code": row.get("status_code"),
+                "headers": row.get("headers", {}),
+                "src_ip": row.get("src_ip"),
+                "dst_ip": row.get("dst_ip"),
+                "src_port": row.get("src_port"),
+                "dst_port": row.get("dst_port"),
+                "raw_row": row,
+            }
+        },
+        "start": timestamp,
+    }
+    stix_objects.append(network_traffic_object)
+
+    observed_data_object = {
+        "type": "observed-data",
+        "id": generate_stix_id("observed-data"),
+        "created_time": timestamp,
+        "first_observed": timestamp,
+        "last_observed": timestamp,
+        "number_observed": 1,
+        "object_refs": [network_traffic_object["id"]],
+        "extensions": {
+            "correlation": corr_id,
+            "note": "Pixie HTTP data wrapped in STIX observed-data"
+        },
+    }
+    stix_objects.append(observed_data_object)
+
+    return stix_objects

--- a/analysis/hive_sentinel/tests/test_pixie_etl.py
+++ b/analysis/hive_sentinel/tests/test_pixie_etl.py
@@ -1,31 +1,70 @@
 import pytest
 import json
+import uuid
 from src.etl.pixie_etl import PixieETL
-
-@pytest.fixture
-def sample_http_columns():
-    return ["time_", "upid", "encrypted", "req_path"]
-
-@pytest.fixture
-def sample_dns_columns():
-    return ["time_", "upid", "encrypted", "req_body"]
 
 @pytest.mark.parametrize("table_name,processed_table,stix_table,column_names,row_data,expected_row", [
     (
         "http_events",
         "http_logs",
         "http_stix",
-        ["time_", "upid", "encrypted", "req_path"],
-        [1234567890, "http-upid", 1, "/test"],
-        [1234567890, "http-upid", 1, "/test"]
+        [
+            "time_", "upid", "encrypted", "req_path",
+            "pod_name", "namespace", "container_id", "pid", "node_name"
+        ],
+        [
+            1234567890,
+            uuid.UUID("00000003-0000-c8d4-0000-00000004354b"),
+            1,
+            "/test",
+            "my-pod",
+            "default",
+            "d2eac5a343c067bacd3327b7a457802e314108a228ce0e6cad08c98824f335e2",
+            51412,
+            "node-01"
+        ],
+        [
+            1234567890,
+            uuid.UUID("00000003-0000-c8d4-0000-00000004354b"),
+            1,
+            "/test",
+            "my-pod",
+            "default",
+            "d2eac5a343c067bacd3327b7a457802e314108a228ce0e6cad08c98824f335e2",
+            51412,
+            "node-01"
+        ]
     ),
     (
         "dns_events",
         "dns_logs",
         "dns_stix",
-        ["time_", "upid", "encrypted", "req_body"],
-        [1234567891, "dns-upid", 0, json.dumps({"queries": [{"name": "example.com", "type": "A"}]})],
-        [1234567891, "dns-upid", 0, json.dumps({"queries": [{"name": "example.com", "type": "A"}]})]
+        [
+            "time_", "upid", "encrypted", "req_body",
+            "pod_name", "namespace", "container_id", "pid", "node_name"
+        ],
+        [
+            1234567891,
+            uuid.UUID("00000003-0000-c8d4-0000-00000004354c"),
+            0,
+            json.dumps({"queries": [{"name": "example.com", "type": "A"}]}),
+            "dns-pod",
+            "dns-namespace",
+            "abcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890",
+            61413,
+            "node-02"
+        ],
+        [
+            1234567891,
+            uuid.UUID("00000003-0000-c8d4-0000-00000004354c"),
+            0,
+            json.dumps({"queries": [{"name": "example.com", "type": "A"}]}),
+            "dns-pod",
+            "dns-namespace",
+            "abcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890",
+            61413,
+            "node-02"
+        ]
     )
 ])
 def test_fetch_and_process_inserts_dual_data(mocker, table_name, processed_table, stix_table, column_names, row_data, expected_row):

--- a/analysis/hive_sentinel/tests/test_pixie_etl.py
+++ b/analysis/hive_sentinel/tests/test_pixie_etl.py
@@ -78,5 +78,3 @@ def test_fetch_and_process_inserts_dual_data(mocker, table_name, processed_table
     # ✅ Ensure last_seen_ns updated correctly
     assert etl.last_seen_ns == row_data[0]
 
-    print(f"✅ Test passed for {table_name}: Inserted STIX row preview:", inserted_rows_stix[0])
-

--- a/analysis/hive_sentinel/tests/test_pixie_stix.py
+++ b/analysis/hive_sentinel/tests/test_pixie_stix.py
@@ -23,7 +23,15 @@ def test_transform_dns_row_to_stix():
     assert isinstance(stix_objects, list)
     assert any(obj["type"] == "network-traffic" for obj in stix_objects)
     assert any(obj["type"] == "observed-data" for obj in stix_objects)
-    print("DNS STIX Transformation Successful:", json.dumps(stix_objects, indent=2))
+
+    # Check that extracted fields exist
+    net_obj = next(obj for obj in stix_objects if obj["type"] == "network-traffic")
+    ext = net_obj["extensions"]["x-pixie-dns-ext"]
+    assert ext["query_name"] == "test.domain.local"
+    assert ext["query_type"] == "A"
+    assert ext["response_code"] == 3
+
+    print("✅ DNS STIX Transformation Successful:\n", json.dumps(stix_objects, indent=2))
 
 def test_transform_http_row_to_stix():
     http_row = {
@@ -55,8 +63,12 @@ def test_transform_http_row_to_stix():
     assert isinstance(stix_objects, list)
     assert any(obj["type"] == "network-traffic" for obj in stix_objects)
     assert any(obj["type"] == "observed-data" for obj in stix_objects)
-    print("HTTP STIX Transformation Successful:", json.dumps(stix_objects, indent=2))
 
-if __name__ == "__main__":
-    test_transform_dns_row_to_stix()
-    test_transform_http_row_to_stix()
+    # Check that extracted fields exist
+    net_obj = next(obj for obj in stix_objects if obj["type"] == "network-traffic")
+    ext = net_obj["extensions"]["x-pixie-http-ext"]
+    assert ext["method"] == "GET"
+    assert "/ping" in ext["url"]
+    assert ext["status_code"] == 200
+
+    print("✅ HTTP STIX Transformation Successful:\n", json.dumps(stix_objects, indent=2))

--- a/analysis/hive_sentinel/tests/test_pixie_stix.py
+++ b/analysis/hive_sentinel/tests/test_pixie_stix.py
@@ -1,0 +1,62 @@
+import json
+from src.stix.pixie.transform_dns_to_stix import transform_dns_row_to_stix
+from src.stix.pixie.transform_http_to_stix import transform_http_row_to_stix
+
+def test_transform_dns_row_to_stix():
+    dns_row = {
+        "time_": 1751871579697,
+        "upid": "00000003-0000-3529-0000-0000000118f6",
+        "remote_addr": "10.43.0.10",
+        "remote_port": 53,
+        "local_addr": "-",
+        "local_port": -1,
+        "trace_role": 1,
+        "encrypted": False,
+        "req_header": json.dumps({"txid": 12521, "qr": 0}),
+        "req_body": json.dumps({"queries": [{"name": "test.domain.local", "type": "A"}]}),
+        "resp_header": json.dumps({"txid": 12521, "qr": 1, "rcode": 3}),
+        "resp_body": json.dumps({"answers": []}),
+        "latency": 1725467
+    }
+
+    stix_objects = transform_dns_row_to_stix(dns_row)
+    assert isinstance(stix_objects, list)
+    assert any(obj["type"] == "network-traffic" for obj in stix_objects)
+    assert any(obj["type"] == "observed-data" for obj in stix_objects)
+    print("DNS STIX Transformation Successful:", json.dumps(stix_objects, indent=2))
+
+def test_transform_http_row_to_stix():
+    http_row = {
+        "time_": 1751871558248,
+        "upid": "00000004-0000-0e03-0000-00000000166d",
+        "remote_addr": "10.42.0.1",
+        "remote_port": 39498,
+        "local_addr": "10.42.0.6",
+        "local_port": 8080,
+        "trace_role": 2,
+        "encrypted": False,
+        "major_version": 1,
+        "minor_version": 1,
+        "content_type": 0,
+        "req_headers": json.dumps({"Host": "10.42.0.6:8080"}),
+        "req_method": "GET",
+        "req_path": "/ping",
+        "req_body": "",
+        "req_body_size": 0,
+        "resp_headers": json.dumps({"Content-Length": "2"}),
+        "resp_status": 200,
+        "resp_message": "OK",
+        "resp_body": "<removed>",
+        "resp_body_size": 2,
+        "latency": 118716
+    }
+
+    stix_objects = transform_http_row_to_stix(http_row)
+    assert isinstance(stix_objects, list)
+    assert any(obj["type"] == "network-traffic" for obj in stix_objects)
+    assert any(obj["type"] == "observed-data" for obj in stix_objects)
+    print("HTTP STIX Transformation Successful:", json.dumps(stix_objects, indent=2))
+
+if __name__ == "__main__":
+    test_transform_dns_row_to_stix()
+    test_transform_http_row_to_stix()

--- a/analysis/hive_sentinel/tests/test_pixie_stix.py
+++ b/analysis/hive_sentinel/tests/test_pixie_stix.py
@@ -11,12 +11,17 @@ def test_transform_dns_row_to_stix():
         "local_addr": "-",
         "local_port": -1,
         "trace_role": 1,
-        "encrypted": False,
+        "encrypted": 0,
         "req_header": json.dumps({"txid": 12521, "qr": 0}),
         "req_body": json.dumps({"queries": [{"name": "test.domain.local", "type": "A"}]}),
         "resp_header": json.dumps({"txid": 12521, "qr": 1, "rcode": 3}),
         "resp_body": json.dumps({"answers": []}),
-        "latency": 1725467
+        "latency": 1725467,
+        "pod_name": "dns-pod",
+        "namespace": "dns-namespace",
+        "container_id": "abcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890",
+        "pid": 61523,
+        "node_name": "node-dns-01"
     }
 
     stix_objects = transform_dns_row_to_stix(dns_row)
@@ -24,7 +29,6 @@ def test_transform_dns_row_to_stix():
     assert any(obj["type"] == "network-traffic" for obj in stix_objects)
     assert any(obj["type"] == "observed-data" for obj in stix_objects)
 
-    # Check that extracted fields exist
     net_obj = next(obj for obj in stix_objects if obj["type"] == "network-traffic")
     ext = net_obj["extensions"]["x-pixie-dns-ext"]
     assert ext["query_name"] == "test.domain.local"
@@ -42,7 +46,7 @@ def test_transform_http_row_to_stix():
         "local_addr": "10.42.0.6",
         "local_port": 8080,
         "trace_role": 2,
-        "encrypted": False,
+        "encrypted": 0,
         "major_version": 1,
         "minor_version": 1,
         "content_type": 0,
@@ -56,7 +60,12 @@ def test_transform_http_row_to_stix():
         "resp_message": "OK",
         "resp_body": "<removed>",
         "resp_body_size": 2,
-        "latency": 118716
+        "latency": 118716,
+        "pod_name": "http-pod",
+        "namespace": "http-namespace",
+        "container_id": "d2eac5a343c067bacd3327b7a457802e314108a228ce0e6cad08c98824f335e2",
+        "pid": 51412,
+        "node_name": "node-http-01"
     }
 
     stix_objects = transform_http_row_to_stix(http_row)
@@ -64,11 +73,8 @@ def test_transform_http_row_to_stix():
     assert any(obj["type"] == "network-traffic" for obj in stix_objects)
     assert any(obj["type"] == "observed-data" for obj in stix_objects)
 
-    # Check that extracted fields exist
     net_obj = next(obj for obj in stix_objects if obj["type"] == "network-traffic")
     ext = net_obj["extensions"]["x-pixie-http-ext"]
     assert ext["method"] == "GET"
     assert "/ping" in ext["url"]
     assert ext["status_code"] == 200
-
-    print("✅ HTTP STIX Transformation Successful:\n", json.dumps(stix_objects, indent=2))

--- a/honeystack/clickhouse/values.yaml
+++ b/honeystack/clickhouse/values.yaml
@@ -54,7 +54,7 @@ configdFiles:
                 <query>
                     CREATE TABLE IF NOT EXISTS default.http_events (
                         time_ UInt64,
-                        upid String,
+                        upid UUID,
                         remote_addr String,
                         remote_port Int32,
                         local_addr String,
@@ -95,7 +95,7 @@ configdFiles:
                 <query>
                     CREATE TABLE IF NOT EXISTS default.dns_events (
                         time_ UInt64,
-                        upid String,
+                        upid UUID,
                         remote_addr String,
                         remote_port Int32,
                         local_addr String,

--- a/honeystack/clickhouse/values.yaml
+++ b/honeystack/clickhouse/values.yaml
@@ -74,6 +74,11 @@ configdFiles:
                         resp_message String,
                         resp_body String,
                         resp_body_size UInt64,
+                        container_id String,
+                        node_name String,
+                        namespace String,
+                        pod_name String,
+                        pid UInt64,
                         latency UInt64
                     ) ENGINE = MergeTree() ORDER BY time_;
                 </query>
@@ -101,6 +106,11 @@ configdFiles:
                         req_body String,
                         resp_header String,
                         resp_body String,
+                        container_id String,
+                        node_name String,
+                        namespace String,
+                        pod_name String,
+                        pid UInt64,
                         latency UInt64
                     ) ENGINE = MergeTree() ORDER BY time_;
                 </query>

--- a/honeystack/clickhouse/values.yaml
+++ b/honeystack/clickhouse/values.yaml
@@ -1,4 +1,3 @@
-
 configdFiles:
   01-startup-scripts.xml: |-
     <clickhouse>
@@ -79,7 +78,14 @@ configdFiles:
                     ) ENGINE = MergeTree() ORDER BY time_;
                 </query>
             </scripts>
-
+            <scripts>
+                <query>
+                    CREATE TABLE IF NOT EXISTS default.http_stix (
+                        timestamp UInt64,
+                        data String
+                    ) ENGINE = MergeTree() ORDER BY timestamp;
+                </query>
+            </scripts>
             <scripts>
                 <query>
                     CREATE TABLE IF NOT EXISTS default.dns_events (
@@ -97,6 +103,15 @@ configdFiles:
                         resp_body String,
                         latency UInt64
                     ) ENGINE = MergeTree() ORDER BY time_;
+                </query>
+            </scripts>
+
+            <scripts>
+                <query>
+                    CREATE TABLE IF NOT EXISTS default.dns_stix (
+                        timestamp UInt64,
+                        data String
+                    ) ENGINE = MergeTree() ORDER BY timestamp;
                 </query>
             </scripts>
 


### PR DESCRIPTION
Converts Pixie HTTP and DNS logs into STIX 2.1 bundles for security pipeline use.

Inserts processed logs into http_logs/dns_logs and STIX bundles into http_stix/dns_stix tables.

Includes tests to validate ETL flow and STIX transformation correctness.

Supports structured correlation and keeps raw_row for debug tracing.