### PR TITLE
Update kubescape and tetragon tables for Pixie clickhouse compatibility

### DIFF
--- a/honeystack/clickhouse/init.sh
+++ b/honeystack/clickhouse/init.sh
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS default.tetragon_stix (
     pod_name String,
     namespace String,
     data String
-) ENGINE = MergeTree();
+) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(event_time)
 ORDER BY (hostname, event_time);
 

--- a/honeystack/clickhouse/init.sh
+++ b/honeystack/clickhouse/init.sh
@@ -29,7 +29,7 @@ PARTITION BY toYYYYMM(event_time)
 ORDER BY (hostname, event_time);
 
 CREATE TABLE IF NOT EXISTS default.tetragon_logs (
-    event_time DateTime64(3)
+    event_time DateTime64(3),
     node_name String,
     type String,
     payload String
@@ -38,7 +38,7 @@ PARTITION BY toYYYYMM(event_time)
 ORDER BY (hostname, event_time);
 
 CREATE TABLE IF NOT EXISTS default.tetragon_stix (
-    event_time DateTime64(3)
+    event_time DateTime64(3),
     timestamp String,
     pod_name String,
     namespace String,

--- a/honeystack/clickhouse/init.sh
+++ b/honeystack/clickhouse/init.sh
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS default.tetragon_stix (
     timestamp String,
     pod_name String,
     namespace String,
+    hostname String,
     data String
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(event_time)

--- a/honeystack/clickhouse/init.sh
+++ b/honeystack/clickhouse/init.sh
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS default.tetragon_logs (
     event_time DateTime64(3),
     node_name String,
     type String,
+    hostname String,
     payload String
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(event_time)

--- a/honeystack/clickhouse/init.sh
+++ b/honeystack/clickhouse/init.sh
@@ -11,29 +11,41 @@ CREATE TABLE IF NOT EXISTS default.kubescape_logs (
     level String,
     message String,
     msg String,
-    time String
-) ENGINE = MergeTree() ORDER BY time;
+    hostname String,
+    event_time DateTime64(3)
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(event_time)
+ORDER BY (hostname, event_time);
 
 CREATE TABLE IF NOT EXISTS default.kubescape_stix (
     timestamp String,
     pod_name String,
     namespace String,
-    data String
-) ENGINE = MergeTree() ORDER BY timestamp;
+    data String,
+    hostname String,
+    event_time DateTime64(3)
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(event_time)
+ORDER BY (hostname, event_time);
 
 CREATE TABLE IF NOT EXISTS default.tetragon_logs (
-    time String,
+    event_time DateTime64(3)
     node_name String,
     type String,
     payload String
-) ENGINE = MergeTree() ORDER BY time;
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(event_time)
+ORDER BY (hostname, event_time);
 
 CREATE TABLE IF NOT EXISTS default.tetragon_stix (
+    event_time DateTime64(3)
     timestamp String,
     pod_name String,
     namespace String,
     data String
-) ENGINE = MergeTree() ORDER BY timestamp;
+) ENGINE = MergeTree();
+PARTITION BY toYYYYMM(event_time)
+ORDER BY (hostname, event_time);
 
 CREATE TABLE IF NOT EXISTS default.matched_attack_patterns (
     timestamp String,

--- a/honeystack/vector/soc.with-clickhouse.yaml
+++ b/honeystack/vector/soc.with-clickhouse.yaml
@@ -346,6 +346,8 @@ customConfig:
       source: |
           .payload = if exists(.process_exec) { .process_exec } else { if exists(.process_exit) { .process_exit } else { if exists(.process_kprobe){ .process_kprobe }  else { "empty" } } }
           .payload.dedup = .dedup
+          .event_time = now()
+          .hostname = if exists(.node_name) { .node_name } else { get_hostname!() }
           del(.process_exec)
           del(.process_exit)
           del(.process_kprobe)
@@ -384,15 +386,17 @@ customConfig:
       inputs:
         - kubescape-nodeagent
       source: |
-        .CloudMetadata = "empty" 
+        .CloudMetadata = "empty"
         .field1 = .BaseRuntimeMetadata.alertName
         .field2 = .RuntimeK8sDetails.containerID
         .field3 = .RuntimeK8sDetails.podName
         .field4 = if exists(.BaseRuntimeMetadata.arguments.capability) { .BaseRuntimeMetadata.arguments.capability } else { if exists(.BaseRuntimeMetadata.arguments.path) { .BaseRuntimeMetadata.arguments.path } else { if exists(.BaseRuntimeMetadata.arguments.exec) { .BaseRuntimeMetadata.arguments.exec } else { "1" } } }
         .field5 = if exists(.RuntimeProcessDetails.processTree.cmdline) { .RuntimeProcessDetails.processTree.cmdline} else {""}
         .field6 = if exists(.BaseRuntimeMetadata.infectedPID) { .BaseRuntimeMetadata.infectedPID } else { "1" }
-        .key, err = to_string(.field1) + to_string(.field2) + to_string(.field3) + to_string(.field4) + to_string(.field5) + to_string(.field6) 
+        .key, err = to_string(.field1) + to_string(.field2) + to_string(.field3) + to_string(.field4) + to_string(.field5) + to_string(.field6)
         .md5_hash = to_string(md5(.key))
+        .hostname = get_hostname!()
+        .event_time = now()
         del(.field1)
         del(.field2)
         del(.field3)

--- a/honeystack/vector/soc.with-clickhouse.yaml
+++ b/honeystack/vector/soc.with-clickhouse.yaml
@@ -459,8 +459,8 @@ customConfig:
       endpoint: "http://hyperdx-hdx-oss-v2-clickhouse.click.svc.cluster.local:8123"
       auth:
         strategy: "basic"
-        user: app
-        password: hyperdx
+        user: otelcollector
+        password: otelcollectorpass
     tetragon: 
       type: file
       inputs:
@@ -477,8 +477,8 @@ customConfig:
       endpoint: "http://hyperdx-hdx-oss-v2-clickhouse.click.svc.cluster.local:8123"
       auth:
         strategy: "basic"
-        user: app
-        password: hyperdx
+        user: otelcollector
+        password: otelcollectorpass
 
 
 


### PR DESCRIPTION
Summary: Update kubescape and tetragon tables for Pixie clickhouse compatibility

These schema changes reflect the changes needed for Pixie to read and write these schemas with Pixie's clickhouse source and sink nodes (read & export support). While Pixie's clickhouse support can be extended to support customizations (like using a separate "time" column for its range query), these are needed to work with the current state of its functionality.

Todo
- [ ] Confirm whether the Pixie clickhouse schema can be removed -- Pixie can create the scheme via PxL (`px.CreateClickHouseSchemas()`)
- [ ] Confirm if stix clickhouse tables will be read or written to via Pixie (otherwise schema for this table can be reverted)
- [ ] Test this end to end with the lab
- [ ] Create lab PR to reflect these changes once e2e testing is complete.