### PR TITLE
Add kubescape anomaly detection script that uses clickhouse source instead of file source

### DIFF
--- a/analysis/px_clickhouse/kubescape/observe.pxl
+++ b/analysis/px_clickhouse/kubescape/observe.pxl
@@ -1,0 +1,10 @@
+
+import px
+
+df = px.DataFrame('kubescape_logs_new', clickhouse_dsn='otelcollector:otelcollectorpass@hyperdx-hdx-oss-v2-clickhouse.click.svc.cluster.local:9000/default', start_time='-2d')
+df.alert = px.pluck(df.BaseRuntimeMetadata, "alertName")
+df.namespace = px.pluck(df.RuntimeK8sDetails, "podNamespace")
+df.podName = px.pluck(df.RuntimeK8sDetails, "podName")
+df.time_ = df.event_time
+df = df[['time_', 'alert', 'namespace', 'podName']]
+px.display(df)


### PR DESCRIPTION
Summary: Add kubescape anomaly detection script that uses clickhouse source instead of file source

This has been tested with our final working Pixie clickhouse changes. It has not been used since the `event_time` column was changed from DateTime64 to a unix timestamp (likely integer column type?)

We need to use [px.int64_to_time](https://docs.px.dev/reference/pxl/udf/int64_to_time/) to handle that conversion.