### PR TITLE
vector-lab: enrich kubescape alerts with MITRE ATT&CK fields

### DIFF
--- a/tree/vector-lab/build-values.sh
+++ b/tree/vector-lab/build-values.sh
@@ -21,7 +21,7 @@ RULES=${1:?usage: $0 <default-rules.yaml>}
 DIR=$(cd "$(dirname "$0")" && pwd)
 VALUES=$DIR/values.yaml
 
-[[ -r $RULES  ]] || { echo "FATAL: rules file not readable: $RULES" >&2; exit 1; }
+[[ -f $RULES  ]] || { echo "FATAL: rules file not found or not a regular file: $RULES" >&2; exit 1; }
 [[ -f $VALUES ]] || { echo "FATAL: values.yaml not at $VALUES" >&2; exit 1; }
 command -v python3 >/dev/null || { echo "FATAL: python3 not found" >&2; exit 1; }
 python3 -c 'import yaml' 2>/dev/null || { echo "FATAL: PyYAML missing — apt install python3-yaml" >&2; exit 1; }
@@ -60,7 +60,8 @@ new = re.sub(
 if new == src:
     sys.stderr.write("FATAL: mitre_map block not found in values.yaml; edit it manually first.\n")
     sys.exit(1)
-open(path, 'w').write(new)
+with open(path, 'w') as f:
+    f.write(new)
 PY
 
 echo "rewrote $VALUES (backup: $VALUES.bak-*)"

--- a/tree/vector-lab/build-values.sh
+++ b/tree/vector-lab/build-values.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# build-values.sh — regenerate the MITRE map embedded in values.yaml
+# from a kubescape default-rules.yaml. Run when rules change.
+#
+# Usage:
+#   ./build-values.sh /path/to/default-rules.yaml
+#
+# The script extracts (id, mitreTactic, mitreTechnique) per rule and
+# rewrites the `mitre_map = {...}` block inside values.yaml in place.
+# A timestamped backup is saved as values.yaml.bak-<epoch>.
+#
+# Why this exists: armoapi-go's BaseRuntimeAlert struct does not carry
+# MitreTactic / MitreTechnique fields, so node-agent never propagates
+# them to its exporters. Until that is fixed upstream, vector enriches
+# the alert with values looked up by RuleID. Rules change rarely, so a
+# static map regenerated on demand is enough.
+
+set -euo pipefail
+
+RULES=${1:?usage: $0 <default-rules.yaml>}
+DIR=$(cd "$(dirname "$0")" && pwd)
+VALUES=$DIR/values.yaml
+
+[[ -r $RULES  ]] || { echo "FATAL: rules file not readable: $RULES" >&2; exit 1; }
+[[ -f $VALUES ]] || { echo "FATAL: values.yaml not at $VALUES" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "FATAL: python3 not found" >&2; exit 1; }
+python3 -c 'import yaml' 2>/dev/null || { echo "FATAL: PyYAML missing — apt install python3-yaml" >&2; exit 1; }
+
+FRAGMENT=$(python3 - "$RULES" <<'PY'
+import yaml, sys
+with open(sys.argv[1]) as f:
+    d = yaml.safe_load(f)
+rows = []
+for r in d.get('spec', {}).get('rules', []):
+    rid = r['id']
+    t   = r.get('mitreTactic',   '')
+    tt  = r.get('mitreTechnique','')
+    rows.append(f'          "{rid}": {{"tactic": "{t}", "technique": "{tt}"}}')
+print('        mitre_map = {')
+print(',\n'.join(rows))
+print('        }')
+PY
+)
+
+cp "$VALUES" "$VALUES.bak-$(date +%s)"
+
+python3 - "$VALUES" "$FRAGMENT" <<'PY'
+import re, sys
+path, fragment = sys.argv[1], sys.argv[2]
+src = open(path).read()
+# Replace the existing mitre_map block (10-spaces indent, opens with
+# "mitre_map = {", closes at the matching brace on its own line).
+new = re.sub(
+    r'        mitre_map = \{[\s\S]*?^        \}',
+    fragment,
+    src,
+    count=1,
+    flags=re.MULTILINE,
+)
+if new == src:
+    sys.stderr.write("FATAL: mitre_map block not found in values.yaml; edit it manually first.\n")
+    sys.exit(1)
+open(path, 'w').write(new)
+PY
+
+echo "rewrote $VALUES (backup: $VALUES.bak-*)"

--- a/tree/vector-lab/values.yaml
+++ b/tree/vector-lab/values.yaml
@@ -61,6 +61,52 @@ customConfig:
         } else {
           .event_time = to_unix_timestamp(now())
         }
+        # MITRE enrichment: node-agent's BaseRuntimeAlert struct (armoapi-go)
+        # does not include mitreTactic / mitreTechnique fields, so they are
+        # absent from the alert payload even though they are defined on the
+        # Rule. Inject them here from a static map (regenerate with
+        # ./build-values.sh <path-to-default-rules.yaml> when rules change).
+        mitre_map = {
+          "R0001": {"tactic": "TA0002", "technique": "T1059"},
+          "R0002": {"tactic": "TA0009", "technique": "T1005"},
+          "R0003": {"tactic": "TA0002", "technique": "T1059"},
+          "R0004": {"tactic": "TA0002", "technique": "T1059"},
+          "R0005": {"tactic": "TA0011", "technique": "T1071.004"},
+          "R0006": {"tactic": "TA0006", "technique": "T1528"},
+          "R0007": {"tactic": "TA0008", "technique": "T1210"},
+          "R0008": {"tactic": "TA0006", "technique": "T1056.001"},
+          "R0009": {"tactic": "TA0011", "technique": "T1095"},
+          "R0010": {"tactic": "TA0006", "technique": "T1005"},
+          "R0011": {"tactic": "TA0010", "technique": "T1041"},
+          "R0012": {"tactic": "TA0005", "technique": "T1564"},
+          "R0040": {"tactic": "TA0002", "technique": "T1059"},
+          "R0041": {"tactic": "TA0011", "technique": "T1071"},
+          "R0042": {"tactic": "TA0005", "technique": "T1564"},
+          "R0043": {"tactic": "TA0001", "technique": "T1190"},
+          "R1000": {"tactic": "TA0002", "technique": "T1059"},
+          "R1001": {"tactic": "TA0005", "technique": "T1574"},
+          "R1002": {"tactic": "TA0008", "technique": "T1021"},
+          "R1003": {"tactic": "TA0005", "technique": "T1620"},
+          "R1004": {"tactic": "TA0011", "technique": "T1090"},
+          "R1005": {"tactic": "TA0005", "technique": "T1055"},
+          "R1006": {"tactic": "TA0004", "technique": "T1611"},
+          "R1007": {"tactic": "TA0040", "technique": "T1496"},
+          "R1008": {"tactic": "TA0011", "technique": "T1071.004"},
+          "R1009": {"tactic": "TA0011", "technique": "T1071"},
+          "R1010": {"tactic": "TA0006", "technique": "T1005"},
+          "R1011": {"tactic": "TA0005", "technique": "T1574.006"},
+          "R1012": {"tactic": "TA0006", "technique": "T1005"},
+          "R1015": {"tactic": "TA0005", "technique": "T1622"},
+          "R1016": {"tactic": "TA0005", "technique": "T1565"},
+          "R1030": {"tactic": "TA0002", "technique": "T1218"},
+          "R1031": {"tactic": "TA0002", "technique": "T1609"}
+        }
+        rule_id = .RuleID || ""
+        m = get(mitre_map, [rule_id]) ?? null
+        if m != null {
+          .BaseRuntimeMetadata.mitreTactic = m.tactic
+          .BaseRuntimeMetadata.mitreTechnique = m.technique
+        }
         del(.time)
 
   sinks:


### PR DESCRIPTION
## Summary

node-agent's stdout exporter emits `BaseRuntimeAlert` (from `armoapi-go`), which has no `MitreTactic` / `MitreTechnique` fields. The Rule definition carries them, but they are never propagated into the alert payload, so downstream sinks (ClickHouse, alertmanager) receive empty MITRE.

Add a static lookup map in the vector `kubescape_enrich` transform that joins the rule-defined values back into `BaseRuntimeMetadata`. Map is keyed by `RuleID` and rebuilt from `default-rules.yaml` via `build-values.sh` when rules change.

## Evidence

Verified on a fresh playground:

- **Before fix:** 0/N rows in `forensic_db.kubescape_logs` had a non-empty `mitreTactic`.
- **After fix:** all rows carry both fields:
  - R0001 → TA0002 / T1059
  - R0002 → TA0009 / T1005
  - R0010 → TA0006 / T1005

Values match the live `default-rules.yaml` exactly, regenerated via:

\`\`\`
./tree/vector-lab/build-values.sh path/to/default-rules.yaml
\`\`\`

## Long-term

The proper upstream fix belongs in `armoapi-go` (add `MitreTactic` / `MitreTechnique` to `BaseRuntimeAlert`) and `node-agent` (populate at alert-creation site), which would propagate to all exporters. This vector enrichment is a workaround until then.

## Test plan

- [ ] On a playground with kubescape + vector + ClickHouse: trigger any rule (e.g. `bobctl attack`), then \`SELECT JSONExtractString(BaseRuntimeMetadata, 'mitreTactic') FROM forensic_db.kubescape_logs LIMIT 5\` — expect non-empty values for every row.
- [ ] When rules change: re-run \`./build-values.sh path/to/default-rules.yaml\`, re-deploy vector with the regenerated values.