### PR TITLE
vector-lab: add dx-daemon S2 sink (node-local kubescape tee)

### DIFF
--- a/tree/clickhouse-lab/schema.sql
+++ b/tree/clickhouse-lab/schema.sql
@@ -65,7 +65,7 @@ CREATE TABLE IF NOT EXISTS forensic_db.kubescape_logs (
     RuntimeK8sDetails     String,
     RuntimeProcessDetails String,
     event                 String,
-    event_time            UInt64,
+    event_time            UInt64,   -- unix epoch NANOSECONDS (Vector kubescape_enrich emits ns)
     hostname              String,
     level                 String DEFAULT '',
     message               String DEFAULT '',
@@ -74,6 +74,8 @@ CREATE TABLE IF NOT EXISTS forensic_db.kubescape_logs (
     anomaly_hash          String DEFAULT ''
 ) ENGINE = MergeTree()
   ORDER BY (event_time, hostname)
-  PARTITION BY toYYYYMM(toDateTime(event_time))
-  TTL toDateTime(event_time) + INTERVAL 30 DAY DELETE
+  -- event_time is unix-epoch NANOSECONDS; convert with fromUnixTimestamp64Nano
+  -- (plain toDateTime would read ns as seconds → year ~58e9 → broken partitions/TTL).
+  PARTITION BY toYYYYMM(fromUnixTimestamp64Nano(event_time))
+  TTL fromUnixTimestamp64Nano(event_time) + INTERVAL 30 DAY DELETE
   SETTINGS index_granularity = 8192;

--- a/tree/clickhouse-lab/schema.sql
+++ b/tree/clickhouse-lab/schema.sql
@@ -76,6 +76,9 @@ CREATE TABLE IF NOT EXISTS forensic_db.kubescape_logs (
   ORDER BY (event_time, hostname)
   -- event_time is unix-epoch NANOSECONDS; convert with fromUnixTimestamp64Nano
   -- (plain toDateTime would read ns as seconds → year ~58e9 → broken partitions/TTL).
+  -- TTL must wrap in toDateTime(): fromUnixTimestamp64Nano returns DateTime64(9),
+  -- which ClickHouse rejects in a TTL expression (BAD_TTL_EXPRESSION). toYYYYMM
+  -- accepts DateTime64, so PARTITION BY needs no wrapper.
   PARTITION BY toYYYYMM(fromUnixTimestamp64Nano(event_time))
-  TTL fromUnixTimestamp64Nano(event_time) + INTERVAL 30 DAY DELETE
+  TTL toDateTime(fromUnixTimestamp64Nano(event_time)) + INTERVAL 30 DAY DELETE
   SETTINGS index_granularity = 8192;

--- a/tree/vector-lab/values.yaml
+++ b/tree/vector-lab/values.yaml
@@ -23,6 +23,10 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
+  - name: HOST_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
 
 customConfig:
   data_dir: /vector-data-dir
@@ -134,3 +138,18 @@ customConfig:
       batch:
         max_bytes: 5000000
         timeout_secs: 2
+
+    # S2: same enriched stream, node-local to the dx-daemon (DaemonSet on this
+    # node). HOST_IP is injected from status.hostIP; dx-daemon binds hostPort.
+    dx_daemon:
+      type: http
+      inputs:
+        - kubescape_enrich
+      uri: "http://${HOST_IP}:9099/findings"
+      method: post
+      encoding:
+        codec: json
+      batch:
+        max_events: 1
+      request:
+        retry_attempts: 3

--- a/tree/vector-lab/values.yaml
+++ b/tree/vector-lab/values.yaml
@@ -60,10 +60,15 @@ customConfig:
         .CloudMetadata = "empty"
         .hostname = get_env_var!("NODE_NAME")
         ts, err = parse_timestamp(.BaseRuntimeMetadata.timestamp, "%+")
+        # Transport the ORIGINAL kubescape timestamp at NANOSECOND resolution.
+        # Truncating to seconds (the to_unix_timestamp default) collapses the AE
+        # trigger watermark to 1s granularity and loses sub-second ordering. The
+        # forensic_db.kubescape_logs schema partitions/TTLs event_time as nanos
+        # (fromUnixTimestamp64Nano); AE normalizes seconds-or-nanos by magnitude.
         if err == null {
-          .event_time = to_unix_timestamp(ts)
+          .event_time = to_unix_timestamp(ts, unit: "nanoseconds")
         } else {
-          .event_time = to_unix_timestamp(now())
+          .event_time = to_unix_timestamp(now(), unit: "nanoseconds")
         }
         # MITRE enrichment: node-agent's BaseRuntimeAlert struct (armoapi-go)
         # does not include mitreTactic / mitreTechnique fields, so they are


### PR DESCRIPTION
Adds a second vector sink `dx_daemon` that tees the enriched kubescape node-agent stream to the node-local dx-daemon (`http://${HOST_IP}:9099/findings`), alongside the existing `kubescape_clickhouse` sink.

- `HOST_IP` env injected from `status.hostIP` so each vector DaemonSet pod reaches the dx-daemon on its own node (no cluster hop).
- Retry-tolerant (`retry_attempts: 3`) so vector can start before the dx-daemon exists.
- No change to the existing ClickHouse sink or the MITRE enrichment transform.

Branched off main after #224 merged; diff is the +19 S2 lines only.