### PR TITLE
feat(vector): TLS on the S2 sink to dx-daemon :9099

### DIFF
--- a/tree/vector-lab/values.yaml
+++ b/tree/vector-lab/values.yaml
@@ -150,8 +150,13 @@ customConfig:
       type: http
       inputs:
         - kubescape_enrich
-      uri: "http://${HOST_IP}:9099/findings"
+      # TLS so findings don't cross the CNI in cleartext. dx serves a self-signed
+      # cert (DX_RECEIVER_TLS=1, entlein/dx#89); skip-verify since honey ns has no
+      # CA. Revert uri to http:// if DX_RECEIVER_TLS is off.
+      uri: "https://${HOST_IP}:9099/findings"
       method: post
+      tls:
+        verify_certificate: false
       encoding:
         codec: json
       batch:


### PR DESCRIPTION
Wire audit (tcpdump on node-01) caught vector POSTing kubescape findings to dx in **cleartext over the CNI** (`http://${HOST_IP}:9099/findings`).

Switch the `dx_daemon` sink to `https://` + `tls.verify_certificate: false`. dx serves a self-signed cert via `DX_RECEIVER_TLS=1` (**entlein/dx#89**); honey ns has no CA so vector skip-verifies — encrypts the channel, which is the point.

**Coordinated flip:** deploy this together with entlein/dx#89 (`DX_RECEIVER_TLS=1`) + the dx readinessProbe `scheme: HTTPS`. If dx receiver TLS is off, revert the uri to `http://`.