### PR TITLE
fix(vector): route findings to dx via node-local Service, not ${HOST_IP}

### DIFF
--- a/tree/vector-lab/dx-daemon-service.yaml
+++ b/tree/vector-lab/dx-daemon-service.yaml
@@ -1,0 +1,38 @@
+# Node-local Service for the dx-daemon findings receiver.
+#
+# WHY THIS EXISTS — the vector -> dx findings delivery used to target
+# `https://${HOST_IP}:9099/findings`, relying on Vector interpolating the node
+# IP (status.hostIP) into the http-sink `uri` at config-load time. That
+# interpolation is unreliable through the timberio/vector `customConfig` path:
+# the literal `${HOST_IP}` reaches Vector's URL parser ("invalid uri
+# character") and every finding is silently dropped, starving dx so it looks
+# blind. (VRL's get_env_var!() works inside a remap, but the http-sink `uri`
+# field is not VRL, so it can't read env at runtime.)
+#
+# This ClusterIP Service replaces the interpolation with a stable DNS name:
+# dx-daemon.honey.svc.cluster.local:9099. `internalTrafficPolicy: Local` makes
+# kube-proxy route only to the dx pod on the SAME node as the caller, so vector
+# still reaches its co-located dx (required for pemdirect's node-local vizier),
+# with no per-node IP, no hostNetwork, and no config-time interpolation.
+# Portable across every node and cluster.
+#
+# dx-daemon is a DaemonSet (one pod per node) owned by dx-agent; this Service
+# is purely additive (selector app=dx-daemon) and does not touch the DaemonSet.
+# Apply it before/with the vector chart:
+#   kubectl apply -f tree/vector-lab/dx-daemon-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: dx-daemon
+  namespace: honey
+  labels:
+    app: dx-daemon
+spec:
+  internalTrafficPolicy: Local
+  selector:
+    app: dx-daemon
+  ports:
+    - name: findings
+      port: 9099
+      targetPort: 9099
+      protocol: TCP

--- a/tree/vector-lab/values.yaml
+++ b/tree/vector-lab/values.yaml
@@ -145,15 +145,24 @@ customConfig:
         timeout_secs: 2
 
     # S2: same enriched stream, node-local to the dx-daemon (DaemonSet on this
-    # node). HOST_IP is injected from status.hostIP; dx-daemon binds hostPort.
+    # node), addressed by a stable DNS name — NOT by interpolating the node IP.
+    #
+    # Vector does NOT reliably interpolate ${HOST_IP} into an http-sink `uri`
+    # through the customConfig path (the literal ${HOST_IP} reaches the URL
+    # parser -> "invalid uri character" -> findings silently dropped -> dx
+    # starves and looks blind). So we route via the dx-daemon ClusterIP Service
+    # with `internalTrafficPolicy: Local`, which delivers only to the dx pod on
+    # THIS node. Node-local, portable, zero interpolation.
+    # Service manifest: tree/vector-lab/dx-daemon-service.yaml (apply it too).
     dx_daemon:
       type: http
       inputs:
         - kubescape_enrich
       # TLS so findings don't cross the CNI in cleartext. dx serves a self-signed
-      # cert (DX_RECEIVER_TLS=1, entlein/dx#89); skip-verify since honey ns has no
-      # CA. Revert uri to http:// if DX_RECEIVER_TLS is off.
-      uri: "https://${HOST_IP}:9099/findings"
+      # cert (DX_RECEIVER_TLS=1, entlein/dx#89); skip-verify since the DNS name
+      # won't match the cert and honey ns has no CA. Revert to http:// if
+      # DX_RECEIVER_TLS is off.
+      uri: "https://dx-daemon.honey.svc.cluster.local:9099/findings"
       method: post
       tls:
         verify_certificate: false


### PR DESCRIPTION
## Problem

The vector → dx findings sink targeted `https://${HOST_IP}:9099/findings`, relying on Vector interpolating the node IP (`status.hostIP`) into the http-sink `uri` at **config-load time**. That interpolation is unreliable through the `timberio/vector` `customConfig` path: the literal `${HOST_IP}` reaches Vector's URL parser (`invalid uri character`) and **every finding is silently dropped**, starving dx so it looks blind. (VRL's `get_env_var!()` works inside a remap — that's how `NODE_NAME` gets in — but the http-sink `uri` field is not VRL, so it can't read env at runtime.)

The stopgap so far was pinning the literal node IP in the live config, which is not portable and re-breaks on every redeploy.

## Fix

Replace the interpolation with a **stable DNS name**:

- New `tree/vector-lab/dx-daemon-service.yaml` — a `dx-daemon` ClusterIP Service in `honey` with **`internalTrafficPolicy: Local`**. dx is a DaemonSet (one pod/node); `Local` makes kube-proxy deliver only to the dx pod on the **same node** as vector, preserving the node-locality that pemdirect's node-local vizier requires.
- `tree/vector-lab/values.yaml` — sink `uri` → `https://dx-daemon.honey.svc.cluster.local:9099/findings`. No per-node IP, no `hostNetwork`, no config-time interpolation. TLS stays `verify_certificate: false` (self-signed cert won't match the DNS name).

## Proof (live rig)

```
$ kubectl -n honey get endpoints dx-daemon
dx-daemon   10.42.0.35:9099,10.42.1.41:9099    # one dx endpoint per node

$ POST {} → https://dx-daemon.honey.svc.cluster.local:9099/findings
HTTP=202 connect=0.27s

# dx resumes producing verdicts (was starved before):
verdict java-poc/... triage=... -> ruled_out generic=MALIGNANT{execution} ...
```

## Notes for review

- The Service is **additive** (`selector: app=dx-daemon`) and does not modify the dx DaemonSet — coordinate with dx-agent only if dx pod labels change.
- `dx-daemon`'s existing `hostPort: 9099` is left untouched (harmless); this Service is an independent, portable delivery path.