### PR TITLE
e2e testing base: SOC stack Skaffold + node-local dx delivery (k3s)

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,107 @@
+# SOC stack — the whole NON-Pixie environment for the e2e / calibration suite.
+#
+# `skaffold deploy -m soc-stack` brings up ClickHouse -> kubescape -> vector (in
+# that order) on k3s. It is designed to be OVERLAID with:
+#   - Pixie's native Skaffold (the `pl` namespace: vizier + adaptive_export), and
+#   - the bob java-poc apps Skaffold (bob/example/java-poc, the sample workloads).
+#
+# Ownership: this repo owns honey (kubescape/vector/dx wiring) + clickhouse. It
+# does NOT own `pl` (Pixie) or the sample apps (bob) — those compose on top.
+#
+# k3s only for now. Everything references the authoritative in-repo configs
+# (tree/clickhouse-lab, tree/kubescape, tree/vector-lab) — no forked copies.
+# ---------------------------------------------------------------------------
+apiVersion: skaffold/v4beta11
+kind: Config
+metadata:
+  name: soc-clickhouse
+manifests:
+  helm:
+    releases:
+      - name: clickhouse-operator
+        repo: https://helm.altinity.com
+        remoteChart: altinity-clickhouse-operator
+        version: 0.26.0
+        namespace: clickhouse
+        createNamespace: true
+  rawYaml:
+    - tree/clickhouse-lab/keeper.yaml
+    - tree/clickhouse-lab/installation.yaml
+deploy:
+  helm: {}
+  kubectl:
+    # After the ClickHouseInstallation CR is applied, wait for the server pod and
+    # load the forensic_db schema (nanosecond timestamps, #227). Mirrors
+    # tree/clickhouse-lab/install.sh. Uses `kubectl wait` (server-side) so there
+    # is no host sleep.
+    hooks:
+      after:
+        - host:
+            command:
+              - bash
+              - -c
+              - |
+                set -euo pipefail
+                NS=clickhouse; CHI=forensic-soc-db
+                kubectl -n "$NS" wait --for=create pod -l clickhouse.altinity.com/chi=$CHI --timeout=120s
+                kubectl -n "$NS" wait --for=condition=Ready pod -l clickhouse.altinity.com/chi=$CHI --timeout=240s
+                P=$(kubectl -n "$NS" get pods -l clickhouse.altinity.com/chi=$CHI -o jsonpath='{.items[0].metadata.name}')
+                kubectl -n "$NS" exec -i "$P" -- clickhouse-client --multiquery < tree/clickhouse-lab/schema.sql
+                echo "forensic_db schema applied"
+            os: [linux, darwin]
+---
+apiVersion: skaffold/v4beta11
+kind: Config
+metadata:
+  name: soc-kubescape
+requires:
+  - configs: [soc-clickhouse]
+manifests:
+  helm:
+    releases:
+      - name: kubescape
+        repo: https://kubescape.github.io/helm-charts/
+        remoteChart: kubescape-operator
+        version: 1.30.2
+        namespace: honey
+        createNamespace: true
+        valuesFiles:
+          - tree/kubescape/values.yaml
+  rawYaml:
+    - tree/kubescape/default-rules.yaml
+deploy:
+  helm: {}
+  kubectl: {}
+---
+apiVersion: skaffold/v4beta11
+kind: Config
+metadata:
+  name: soc-vector
+requires:
+  - configs: [soc-kubescape]
+manifests:
+  helm:
+    releases:
+      - name: vector
+        repo: https://helm.vector.dev
+        remoteChart: vector
+        # TODO(#230): pin the vector chart version for reproducibility.
+        namespace: honey
+        createNamespace: true
+        valuesFiles:
+          - tree/vector-lab/values.yaml
+  rawYaml:
+    # node-local delivery to dx (#228) — replaces the fragile ${HOST_IP} sink.
+    - tree/vector-lab/dx-daemon-service.yaml
+deploy:
+  helm: {}
+  kubectl: {}
+---
+# Entry point: `skaffold deploy -m soc-stack` deploys clickhouse -> kubescape ->
+# vector via the requires chain above.
+apiVersion: skaffold/v4beta11
+kind: Config
+metadata:
+  name: soc-stack
+requires:
+  - configs: [soc-vector]

--- a/tree/vector-lab/dx-daemon-service.yaml
+++ b/tree/vector-lab/dx-daemon-service.yaml
@@ -1,0 +1,38 @@
+# Node-local Service for the dx-daemon findings receiver.
+#
+# WHY THIS EXISTS — the vector -> dx findings delivery used to target
+# `https://${HOST_IP}:9099/findings`, relying on Vector interpolating the node
+# IP (status.hostIP) into the http-sink `uri` at config-load time. That
+# interpolation is unreliable through the timberio/vector `customConfig` path:
+# the literal `${HOST_IP}` reaches Vector's URL parser ("invalid uri
+# character") and every finding is silently dropped, starving dx so it looks
+# blind. (VRL's get_env_var!() works inside a remap, but the http-sink `uri`
+# field is not VRL, so it can't read env at runtime.)
+#
+# This ClusterIP Service replaces the interpolation with a stable DNS name:
+# dx-daemon.honey.svc.cluster.local:9099. `internalTrafficPolicy: Local` makes
+# kube-proxy route only to the dx pod on the SAME node as the caller, so vector
+# still reaches its co-located dx (required for pemdirect's node-local vizier),
+# with no per-node IP, no hostNetwork, and no config-time interpolation.
+# Portable across every node and cluster.
+#
+# dx-daemon is a DaemonSet (one pod per node) owned by dx-agent; this Service
+# is purely additive (selector app=dx-daemon) and does not touch the DaemonSet.
+# Apply it before/with the vector chart:
+#   kubectl apply -f tree/vector-lab/dx-daemon-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: dx-daemon
+  namespace: honey
+  labels:
+    app: dx-daemon
+spec:
+  internalTrafficPolicy: Local
+  selector:
+    app: dx-daemon
+  ports:
+    - name: findings
+      port: 9099
+      targetPort: 9099
+      protocol: TCP

--- a/tree/vector-lab/values.yaml
+++ b/tree/vector-lab/values.yaml
@@ -145,15 +145,24 @@ customConfig:
         timeout_secs: 2
 
     # S2: same enriched stream, node-local to the dx-daemon (DaemonSet on this
-    # node). HOST_IP is injected from status.hostIP; dx-daemon binds hostPort.
+    # node), addressed by a stable DNS name — NOT by interpolating the node IP.
+    #
+    # Vector does NOT reliably interpolate ${HOST_IP} into an http-sink `uri`
+    # through the customConfig path (the literal ${HOST_IP} reaches the URL
+    # parser -> "invalid uri character" -> findings silently dropped -> dx
+    # starves and looks blind). So we route via the dx-daemon ClusterIP Service
+    # with `internalTrafficPolicy: Local`, which delivers only to the dx pod on
+    # THIS node. Node-local, portable, zero interpolation.
+    # Service manifest: tree/vector-lab/dx-daemon-service.yaml (apply it too).
     dx_daemon:
       type: http
       inputs:
         - kubescape_enrich
       # TLS so findings don't cross the CNI in cleartext. dx serves a self-signed
-      # cert (DX_RECEIVER_TLS=1, entlein/dx#89); skip-verify since honey ns has no
-      # CA. Revert uri to http:// if DX_RECEIVER_TLS is off.
-      uri: "https://${HOST_IP}:9099/findings"
+      # cert (DX_RECEIVER_TLS=1, entlein/dx#89); skip-verify since the DNS name
+      # won't match the cert and honey ns has no CA. Revert to http:// if
+      # DX_RECEIVER_TLS is off.
+      uri: "https://dx-daemon.honey.svc.cluster.local:9099/findings"
       method: post
       tls:
         verify_certificate: false


### PR DESCRIPTION
Consolidation base for reproducible e2e testing, paired with pixie [#68](https://github.com/k8sstormcenter/pixie/pull/68). **No new features** — deploy plumbing + the vector→dx fix, so the calibration suite can stand up the whole non-Pixie stack with one command.

## Contents

1. **`skaffold.yaml`** — `skaffold deploy -m soc-stack` deploys the non-Pixie environment in order: **ClickHouse → kubescape → vector**, from the authoritative in-repo configs (`tree/clickhouse-lab`, `tree/kubescape`, `tree/vector-lab`). Pinned: clickhouse-operator `0.26.0`, kubescape `1.30.2`. ClickHouse schema (`forensic_db`, nanosecond timestamps) applied via a post-deploy hook. k3s only.
2. **vector→dx node-local Service** (folds in #228) — `tree/vector-lab/dx-daemon-service.yaml` + sink → `dx-daemon.honey.svc.cluster.local:9099`, replacing the fragile `${HOST_IP}` interpolation that silently dropped findings.

## Overlay model

- **this repo** owns `honey` (kubescape/vector/dx wiring) + `clickhouse`.
- **Pixie's native Skaffold** owns `pl` (vizier + adaptive_export).
- **bob** [k8sstormcenter/bob#152](https://github.com/k8sstormcenter/bob/pull/152) owns the java-poc sample apps + SBoBs.

The pixie #68 e2e suite composes all three: soc stack → bob sbobs+apps → Pixie.

## Notes
- Supersedes #228 (its vector fix is included here as the consolidation base).
- Vector chart version still needs pinning (#230); dx-daemon deploy ownership to be resolved in the cleanup issues.
- Relates to #229 (e2e encryption), #230 (fully pinned Skaffold).