### PR TITLE
fix(skaffold): server-side apply for the altinity CRD bundle (k3s)

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -30,6 +30,12 @@ manifests:
 deploy:
   helm: {}
   kubectl:
+    # Server-side apply: the altinity operator ships a CRD bundle whose ConfigMap
+    # exceeds the 262144-byte client-side last-applied-configuration annotation
+    # limit. SSA stores no such annotation; --force-conflicts takes field
+    # ownership from helm's manager on reconcile.
+    flags:
+      apply: ["--server-side", "--force-conflicts"]
     # After the ClickHouseInstallation CR is applied, wait for the server pod and
     # load the forensic_db schema (nanosecond timestamps, #227). Mirrors
     # tree/clickhouse-lab/install.sh. Uses `kubectl wait` (server-side) so there
@@ -71,7 +77,9 @@ manifests:
     - tree/kubescape/default-rules.yaml
 deploy:
   helm: {}
-  kubectl: {}
+  kubectl:
+    flags:
+      apply: ["--server-side", "--force-conflicts"]
 ---
 apiVersion: skaffold/v4beta11
 kind: Config
@@ -95,7 +103,9 @@ manifests:
     - tree/vector-lab/dx-daemon-service.yaml
 deploy:
   helm: {}
-  kubectl: {}
+  kubectl:
+    flags:
+      apply: ["--server-side", "--force-conflicts"]
 ---
 # Entry point: `skaffold deploy -m soc-stack` deploys clickhouse -> kubescape ->
 # vector via the requires chain above.


### PR DESCRIPTION
Follow-up to #231, surfaced by retesting the `e2e-nonpixie` deploy against merged main.

`skaffold deploy -m soc-stack` aborted on the clickhouse-operator chart:
```
ConfigMap "clickhouse-operator-...-crds" is invalid:
metadata.annotations: Too long: may not be more than 262144 bytes
```
Client-side `kubectl apply` stores the full object in the `last-applied-configuration` annotation; the altinity operator's CRD bundle exceeds the 262144-byte limit. **Server-side apply** stores no such annotation (`--force-conflicts` takes field ownership from helm's manager on reconcile). Applied to all three kubectl deployers.

**Verified live**: full `soc-stack` deploy completes — 87 objects `serverside-applied`, 0 errors, ClickHouse → kubescape → vector. Refs #231, pixie #68.