### PR TITLE
fix(vector): drop-on-full buffer on the dx sink (a down dx must not stall ClickHouse)

### DIFF
--- a/tree/vector-lab/values.yaml
+++ b/tree/vector-lab/values.yaml
@@ -172,3 +172,13 @@ customConfig:
         max_events: 1
       request:
         retry_attempts: 3
+      # Drop-on-full: dx is an OPTIONAL, node-local sink. If dx-daemon is down
+      # (not deployed yet, restarting, or its receiver refuses), the default
+      # when_full=block back-pressures the shared kubescape_enrich transform and
+      # STALLS the kubescape_clickhouse sink too — so kubescape findings stop
+      # reaching ClickHouse (and therefore AE). A down dx must never stall the
+      # forensic pipeline: drop dx findings rather than block.
+      buffer:
+        type: memory
+        max_events: 500
+        when_full: drop_newest


### PR DESCRIPTION
## Problem
`dx_daemon` is an optional, node-local http sink. With vector's default `when_full=block`, when dx-daemon is down (not deployed, restarting, or refusing the connection) its buffer fills and **back-pressures the shared `kubescape_enrich` transform**, which stalls the `kubescape_clickhouse` sink too — kubescape findings stop reaching ClickHouse (and AE). Surfaced on a dx-less e2e rig: cplane-01's CH data froze 25 min stale.

## Fix
```yaml
buffer:
  type: memory
  max_events: 500
  when_full: drop_newest
```
on the dx sink — drop dx findings under pressure instead of blocking the forensic pipeline.

## Verified live
Before: cplane-01 kubescape_logs frozen. After (dx still absent): ClickHouse drains again — R0003/R0010 land, kubescape_logs fresh, AE `adaptive_attribution` grows.

Refs pixie #68 (calibration pipeline), #228/#231.