### PR TITLE
fix(kubescape): soc-owned runtime rules — R0002 on, R0003 off, R0011 on

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -74,12 +74,22 @@ manifests:
         valuesFiles:
           - tree/kubescape/values.yaml
   rawYaml:
+    # soc owns the runtime rule set + binding (helm's alertCRD.installDefault is
+    # false in values.yaml), so our enabled flags win instead of racing helm.
     - tree/kubescape/default-rules.yaml
+    - tree/kubescape/rule-alert-binding.yaml
 deploy:
   helm: {}
   kubectl:
     flags:
       apply: ["--server-side", "--force-conflicts"]
+    hooks:
+      # node-agent loads rules at boot; on redeploy (or if it started before the
+      # rawYaml rules landed) bounce it so R0002-on/R0003-off/R0011-on take effect.
+      after:
+        - host:
+            command: ["sh", "-c", "kubectl -n honey rollout restart ds/node-agent >/dev/null 2>&1 || true"]
+            os: [linux, darwin]
 ---
 apiVersion: skaffold/v4beta11
 kind: Config

--- a/tree/kubescape/default-rules.yaml
+++ b/tree/kubescape/default-rules.yaml
@@ -267,7 +267,7 @@ spec:
     - description: >-
         Detecting unexpected egress network traffic that is not whitelisted by
         application profile.
-      enabled: false
+      enabled: true
       expressions:
         message: >-
           'Unexpected egress network communication to: ' + event.dstAddr + ':' +
@@ -280,7 +280,7 @@ spec:
               && !nn.was_address_in_egress(event.containerId, event.dstAddr)
         uniqueId: event.dstAddr + '_' + string(event.dstPort) + '_' + event.proto
       id: R0011
-      isTriggerAlert: false
+      isTriggerAlert: true
       mitreTactic: TA0010
       mitreTechnique: T1041
       name: Unexpected Egress Network Traffic

--- a/tree/kubescape/rule-alert-binding.yaml
+++ b/tree/kubescape/rule-alert-binding.yaml
@@ -1,0 +1,69 @@
+# soc-owned RuntimeRuleAlertBinding.
+#
+# With alertCRD.installDefault:false (tree/kubescape/values.yaml) the kubescape
+# helm chart no longer ships its own all-rules-all-pods binding, so soc supplies
+# it here. This binds the runtime rules to every workload namespace (the NotIn
+# list mirrors values.yaml excludeNamespaces). Whether a bound rule actually
+# fires is still gated by its `enabled` flag in default-rules.yaml
+# (R0002 on, R0003 off, R0011 on).
+#
+# "Syscalls Anomalies in container" (R0003) is intentionally NOT bound here —
+# we are not monitoring syscalls (it emits pid-less PID-0 events that AE cannot
+# attribute; disabled in default-rules.yaml too).
+apiVersion: kubescape.io/v1
+kind: RuntimeRuleAlertBinding
+metadata:
+  name: all-rules-all-pods
+  namespace: honey
+  labels:
+    kubescape.io/ignore: "true"
+    tier: ks-control-plane
+spec:
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+          - kubescape
+          - kube-system
+          - kube-flannel
+          - ingress-nginx
+          - olm
+          - px-operator
+          - honey
+          - pl
+          - clickhouse
+          - kube-public
+          - kube-node-lease
+          - local-path-storage
+          - gmp-system
+          - gmp-public
+          - storm
+          - lightening
+          - cert-manager
+  rules:
+    - ruleName: Unexpected process launched
+    - ruleName: Files Access Anomalies in container
+    - ruleName: Linux Capabilities Anomalies in container
+    - ruleName: DNS Anomalies in container
+    - ruleName: Unexpected service account token access
+    - ruleName: Workload uses Kubernetes API unexpectedly
+    - ruleName: Process executed from malicious source
+    - ruleName: Process tries to load a kernel module
+    - ruleName: Drifted process executed
+    - ruleName: Disallowed ssh connection
+    - ruleName: Fileless execution detected
+    - ruleName: Crypto miner launched
+    - ruleName: Process executed from mount
+    - ruleName: Crypto Mining Related Port Communication
+    - ruleName: Crypto Mining Domain Communication
+    - ruleName: Read Environment Variables from procfs
+    - ruleName: eBPF Program Load
+    - ruleName: Soft link created over sensitive file
+    - ruleName: Unexpected Sensitive File Access
+    - ruleName: Hard link created over sensitive file
+    - ruleName: Exec to pod
+    - ruleName: Port forward
+    - ruleName: Unexpected Egress Network Traffic
+    - ruleName: Malicious Ptrace Usage
+    - ruleName: Unexpected io_uring Operation Detected

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -18,9 +18,19 @@ nodeAgent:
       ruleCooldownMaxSize: 20000
 capabilities:
   runtimeDetection: enable
+  # networkEventsStreaming stays DISABLED on purpose: the rule engine receives
+  # network+DNS events directly (node-agent container_watcher.go), independent
+  # of the raw network-stream export. Enabling it only drives the httpExporter
+  # (empty url -> "unsupported protocol scheme" dead error). See bob #127/#140 +
+  # memory log4j-network-detection-chain. R0011/R0005 fire without it.
   networkEventsStreaming: disable
 alertCRD:
-  installDefault: true
+  # installDefault:false -> the helm chart does NOT create its own default-rules
+  # Rules object nor the all-rules-all-pods binding. soc owns both via rawYaml
+  # (default-rules.yaml + rule-alert-binding.yaml) so our enabled flags
+  # (R0002 on, R0003 off, R0011 on) win deterministically instead of losing the
+  # dual-ownership race to the chart's helm-managed defaults.
+  installDefault: false
   scopeClustered: true
 clusterName: bobexample
 ksNamespace: honey


### PR DESCRIPTION
## Problem

The kubescape-operator helm chart (`alertCRD.installDefault: true`) creates a **helm-managed** `default-rules` Rules object **and** the `all-rules-all-pods` binding. soc's rawYaml `default-rules.yaml` co-defined the same object, so the two raced for ownership on every deploy and the **chart's defaults won** — `R0002` (Files Access Anomalies) stayed **off** and `R0003` (Syscalls Anomalies) stayed **on**, no matter what soc's file said. `R0003` also floods the pipeline: it emits pid-less "PID 0" events that the adaptive-export operator cannot attribute (skipped per-row).

## Fix — soc owns the runtime rule set outright

- **`values.yaml`**: `alertCRD.installDefault: false` → the chart no longer ships its own rules/binding. `networkEventsStreaming` stays `disable` **on purpose**: the node-agent rule engine receives network+DNS events directly (`container_watcher.go`), independent of the raw network-stream export (whose empty `httpExporterConfig.url` just yields the "unsupported protocol scheme" dead error). So `R0011`/`R0005` fire without it.
- **`tree/kubescape/rule-alert-binding.yaml`** (new): soc-owned `all-rules-all-pods` binding. `Syscalls Anomalies in container` (R0003) is intentionally **not** bound — we do not monitor syscalls.
- **`default-rules.yaml`**: `R0011` `enabled: true` + `isTriggerAlert: true` (`R0002` already on, `R0003` already off).
- **`skaffold.yaml`**: deploy the binding via rawYaml + an `after` hook that bounces `node-agent` so rule changes load.

**Net: R0002 ON, R0003 OFF, R0011 ON — deterministically, winning over the chart defaults.**

## Validation (live)

Applied to a running rig via `kubectl apply --server-side --force-conflicts` over the helm objects, node-agent reloaded:

- **R0002 ON** — fires: `Unexpected file access detected: … to /lib/libc.so.6` (0 → 134k rows; note this rule is high-volume by design).
- **R0011 ON** — fires: `Unexpected egress network communication to: 8.8.8.8:80 using TCP from: backend`.
- **R0003 OFF** — zero new rows.
- Binding no longer lists `Syscalls Anomalies in container`.