### PR TITLE
fix(clickhouse): ingest_writer needs allow_ddl=1 + async_insert=0 for AE

### DIFF
--- a/tree/clickhouse-lab/installation.yaml
+++ b/tree/clickhouse-lab/installation.yaml
@@ -40,10 +40,10 @@ spec:
       # and vector's sink appends its own ?query=… — the two collide
       # and throw DB::Exception code 467 "Cannot parse bool".
       ingest_service/readonly: "0"
-      ingest_service/allow_ddl: "0"
+      ingest_service/allow_ddl: "1"
       ingest_service/allow_experimental_lightweight_delete: "0"
       ingest_service/allow_nondeterministic_mutations: "0"
-      ingest_service/async_insert: "1"
+      ingest_service/async_insert: "0"
       ingest_service/async_insert_max_data_size: "10485760"
       ingest_service/async_insert_busy_timeout_ms: "200"
 


### PR DESCRIPTION
## Problem

A clean deploy of this repo (`skaffold deploy -m soc-stack`) leaves the adaptive-export (AE) operator unable to populate `forensic_db`. Two settings on the `ingest_service` profile in `tree/clickhouse-lab/installation.yaml` are the cause:

**1. `allow_ddl: "0"`** — AE **owns** the `forensic_db` schema: on boot it runs `CREATE DATABASE` + `CREATE TABLE IF NOT EXISTS` for every operator-owned table (protocol tables + `adaptive_attribution`/`trigger_watermark`/`ae_reconcile` + `dx_evidence_graph`/`_malignant`/`_manifest`) as the `ingest_writer` DSN user. With DDL prohibited it fatals on the first statement:
```
Code 392: DDL queries are prohibited for the user ingest_writer (QUERY_IS_PROHIBITED)
```
and creates **zero** tables — `forensic_db` then only has the soc-owned `alerts` + `kubescape_logs` from `schema.sql`, and every pixie/dx table is missing.

**2. `async_insert: "1"`** — every AE insert returns `written_rows=0` immediately, and AE logs:
```
sink: pixie write to <table> reported N rows_sent but CH summary written_rows=0 (silent drop)
```
Rows are deferred/dropped under load, so `pgsql_events`/`http_events`/etc. do not reliably land. AE writes synchronously and verifies the ClickHouse response — it needs `async_insert=0`.

## Fix

```diff
-      ingest_service/allow_ddl: "0"
+      ingest_service/allow_ddl: "1"
-      ingest_service/async_insert: "1"
+      ingest_service/async_insert: "0"
```

- `allow_ddl=1` — AE must create its own tables (it is the schema owner; `schema.sql` deliberately creates only the soc-owned `alerts`/`kubescape_logs`).
- `async_insert=0` — AE writes must be synchronous + verifiable, which is what the reconcile/no-loss accounting already assumes.

`vector` shares the `ingest_writer` user but only `INSERT`s, so the DDL grant is unused by it.

## Validation (live)

Applied to a running rig via CHI reconcile (updates the users profile in-place, ~50s, no data/pod wipe), then restarted AE:
- `allow_ddl=1` → AE self-creates **all 21** operator-owned tables (`forensic_db` went 2 → 21 tables).
- `async_insert=0` → **silent-drop warnings gone**; `forensic_db.pgsql_events` populates with real `backend→postgres` queries (`SELECT id,name,sku,category,price_cents,stock FROM products…`).