### PR TITLE
skaffold: pin kubescape 1.40.3 + node-agent/storage sbob-rc4 (ContainerProfile stack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,86 @@ THIS IS CURRENTLY NOT PRODUCTION READY and NOT STABLE, there is no governance or
 > This repo contains the deployment artefacts for a sovereign SOC stack -- all development currently is on the individual repos (see the pixie/fork and the node-agent/fork and bob). The old code has been moved into the `deprecated` folder.
 >
 
+## Install
+
+Prereqs: a `k3s` cluster (real kernel / eBPF) with **Pixie** deployed and registered.
+
+```bash
+# 1. The soc stack, in dependency order: ClickHouse (forensic_db) ->
+#    kubescape 1.40.3 + node-agent/storage sbob-rc4 (ContainerProfile) -> vector.
+skaffold run -m soc-stack
+
+# 2. Adaptive Export (AE) — reads kubescape_logs and exports the CORRELATED
+#    Pixie evidence into forensic_db. It self-creates the schema (needs
+#    ingest_service/allow_ddl:"1", see tree/clickhouse-lab/installation.yaml),
+#    registers the retention export scripts, and deploys the dark-vector
+#    tracepoints.
+kubectl -n pl set image ds/adaptive-export \
+  adaptive-export=ghcr.io/k8sstormcenter/vizier-adaptive_export_image:0.14.19-aeprod47
+kubectl -n pl set env ds/adaptive-export \
+  INSTALL_PRESET_SCRIPTS=true \
+  CLICKHOUSE_USER=ingest_writer CLICKHOUSE_PASSWORD=changeme-ingest \
+  CLICKHOUSE_HOST=clickhouse-forensic-soc-db.clickhouse.svc.cluster.local \
+  CLICKHOUSE_PORT=9000 CLICKHOUSE_DATABASE=forensic_db
+```
+
+## Run the e2e test (redis)
+
+Deploys the vulnerable Redis + its user-defined ContainerProfile, fires the
+post-compromise stage-2 attacks, and proves from the **live** `forensic_db`
+that each kubescape rule fired **and** that the Pixie evidence AE exported for
+it is stored. Harness: [`bob@feat/cp-artifacts` / dx `e2e/redis`](https://github.com/k8sstormcenter/bob).
+
+```bash
+./run-redis-e2e.sh            # deploy redis -> bind SBoB -> attack -> assert
+```
+
+Expected: `RESULT: PASS` with rules `R0001 / R0005 / R0008 / R0010 / R1008` in
+`kubescape_logs` and the correlated evidence in `dns_events`, `conn_stats`,
+`http_events`, `dc_snoop`, `stack_trace`.
+
+## What you get: real evidence in ClickHouse
+
+Kubescape gives you the coarse **alert**; Pixie (via AE) gives you the
+**forensic evidence**, and both land in `forensic_db` correlated by pod +
+process. From one redis attack run:
+
+**The alert** — `forensic_db.kubescape_logs`:
+```
+RuleID:   R1008
+message:  Communication with a known crypto mining domain: xmr.pool.minergate.com.
+hostname: cplane-01
+```
+
+**The captured C2 lookup** — `forensic_db.dns_events`:
+```
+time_:     2026-07-28 18:49:46.066529127
+req_body:  {"queries":[{"name":"xmr.pool.minergate.com","type":"A"}]}
+```
+
+**The offending process, attributed to the pod** — `forensic_db.dc_snoop`:
+```
+time_:     2026-07-28 18:49:42.011220101
+pid:       1041819
+comm:      sh
+namespace: redis
+pod:       redis/redis-74d544d5f9-dpx4r
+container: redis
+hostname:  cplane-01
+```
+
+**The detection, per rule** — `forensic_db.kubescape_logs`:
+```
+R0001   Unexpected process launched: whoami with PID 1042137
+R0001   Unexpected process launched: getent with PID 1042536
+R0001   Unexpected process launched: cat    with PID 1043393
+R1008   Communication with a known crypto mining domain: xmr.pool.minergate.com.
+```
+
+That one ~90 s attack produced, in `forensic_db`: **dns_events 411k · conn_stats
+596k · http_events 1.15M · dc_snoop 51.8M · stack_trace 399k** rows — the full
+kernel + network picture, correlated to each kubescape rule. The whole point:
+kubescape anchors *when/what* is suspicious; Pixie supplies *the evidence*, and
+the adaptive write keeps only what an anomaly actually needs.
+
+

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -68,7 +68,7 @@ manifests:
       - name: kubescape
         repo: https://kubescape.github.io/helm-charts/
         remoteChart: kubescape-operator
-        version: 1.30.2
+        version: 1.40.3
         namespace: honey
         createNamespace: true
         valuesFiles:

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -1,12 +1,12 @@
 storage:
   image:
     repository: ghcr.io/k8sstormcenter/storage
-    tag: "dev-e64d59a"
+    tag: "sbob-rc4"
 
 nodeAgent:
   image:
     repository: ghcr.io/k8sstormcenter/node-agent
-    tag: "dev-e64d59a"
+    tag: "sbob-rc4"
   config:
     maxLearningPeriod: 2m
     learningPeriod: 2m 


### PR DESCRIPTION
## Why
The `soc-kubescape` skaffold module pinned **kubescape-operator 1.30.2** with the old **`dev-e64d59a`** node-agent/storage images — predating the unified ContainerProfile stack, so user-defined `ContainerProfile` SBoBs don't bind. Found while standing up the redis kubescape e2e (bob `feat/cp-artifacts`) on a fresh rig.

## What
Align with bob@`feat/cp-artifacts` `make kubescape`:
- kubescape-operator chart **1.30.2 → 1.40.3** (the released version)
- node-agent + storage images **→ `sbob-rc4`** (node-agent binds a single CP by the `kubescape.io/user-defined-profile` pod label; storage serves the ContainerProfile CRD)

## Verified
Applied live on a clean pixie rig: with `--take-ownership` (chart was skaffold/kubectl-SSA-owned) the upgrade lands 1.40.3 + sbob-rc4; ContainerProfile CRD present, `default-rules` applied, `networkStreamingEnabled: true`, all honey pods healthy.

## Follow-up (not in this PR)
bob's `make kubescape` additionally does `helm show crds … | kubectl apply` (helm upgrade **skips CRDs**) and enable-streaming. The skaffold helm deploy does neither — a bare `skaffold run -m soc-kubescape` should add these as deploy hooks to yield a fully working stack.