### PR TITLE
clickhouse: allow_ddl=1 for ingest_service (AE creates forensic_db tables)

### DIFF
--- a/tree/clickhouse-lab/installation.yaml
+++ b/tree/clickhouse-lab/installation.yaml
@@ -40,7 +40,7 @@ spec:
       # and vector's sink appends its own ?query=… — the two collide
       # and throw DB::Exception code 467 "Cannot parse bool".
       ingest_service/readonly: "0"
-      ingest_service/allow_ddl: "0"
+      ingest_service/allow_ddl: "1"
       ingest_service/allow_experimental_lightweight_delete: "0"
       ingest_service/allow_nondeterministic_mutations: "0"
       ingest_service/async_insert: "1"


### PR DESCRIPTION
## Why
On a fresh rig the adaptive_export operator (`ingest_writer`, via the `ingest_service` profile) **crashloops** creating the forensic_db schema:
```
schema apply failed … create database forensic_db: Code: 392.
DDL queries are prohibited for the user ingest_writer. (QUERY_IS_PROHIBITED)
```
because `profiles.ingest_service/allow_ddl` is `"0"`.

## Fix
`ingest_service/allow_ddl: "0" → "1"`. The AE owns table creation (apply.go: CREATE DATABASE + CREATE TABLE); `forensic_analyst` stays readonly.

## Verified live
Patched this on a clean rig → AE boots, `pixie table schemas verified — 12 tables`, retention export writes (dns_events/conn_stats/http_events populate). Found while standing up the redis kubescape→forensic_db e2e.