### PR TITLE
clickhouse-lab: right-size ClickHouse pod resources for lab PGs

### DIFF
--- a/tree/clickhouse-lab/installation.yaml
+++ b/tree/clickhouse-lab/installation.yaml
@@ -75,11 +75,11 @@ spec:
           image: clickhouse/clickhouse-server:24.8
           resources:
             requests:
-              memory: 4Gi
-              cpu: 2
+              memory: 512Mi
+              cpu: 250m
             limits:
-              memory: 16Gi
-              cpu: 8
+              memory: 2Gi
+              cpu: "2"
 
     volumeClaimTemplates:
     - name: data-volume


### PR DESCRIPTION
The 1×1 forensic ClickHouse in `tree/clickhouse-lab/installation.yaml` requested **cpu: 2 / memory: 4Gi** (limits cpu: 8 / memory: 16Gi) — production-sized.

On a standard k3s PG the 2-CPU/4Gi *request* fails to schedule:

```
Warning  FailedScheduling  default-scheduler  0/2 nodes are available:
1 Insufficient cpu, 1 Insufficient memory.
```

The pod hangs `Pending` and `skaffold deploy -m soc-stack` wedges at the clickhouse module.

**Change:** requests → `cpu: 250m` / `memory: 512Mi`, limits → `cpu: 2` / `memory: 2Gi`. Ample for the forensic ingest load and schedulable on any lab PG. No other config touched (PVC still 5Gi, schema/nanosecond timestamps unchanged).