### PR TITLE
clickhouse-lab: restore CH limits to validated 16Gi/8

### DIFF
--- a/tree/clickhouse-lab/installation.yaml
+++ b/tree/clickhouse-lab/installation.yaml
@@ -78,8 +78,8 @@ spec:
               memory: 512Mi
               cpu: 250m
             limits:
-              memory: 2Gi
-              cpu: "2"
+              memory: 16Gi
+              cpu: 8
 
     volumeClaimTemplates:
     - name: data-volume


### PR DESCRIPTION
Follow-up to #243.

#243 correctly lowered ClickHouse **requests** (`cpu 2 -> 250m`, `memory 4Gi -> 512Mi`) so the pod schedules on lab PGs. But it also lowered the **limits** from `16Gi/8` to `2Gi/2` — which was never validated.

- Scheduling only checks *requests* (identical in both), so the change is invisible at deploy time.
- Under load it is not: a `2Gi` memory **limit** can OOM-kill ClickHouse during forensic ingest + `FINAL` dedup queries.

The live `sed` that was confirmed working on the rig only touched requests and left limits at `16Gi/8`. This restores that exact, validated shape:

| | requests | limits |
|---|---|---|
| working patch / this PR | 512Mi / 250m | **16Gi / 8** |
| #243 (regressed limits) | 512Mi / 250m | 2Gi / 2 |

Limits are a burst ceiling, not a reservation, so restoring `16Gi/8` does **not** affect schedulability — the Pending-pod fix from #243 is fully preserved.