### PR TITLE
kubescape: sync values + rules + binding from bob main

### DIFF
--- a/tree/kubescape/default-rules.yaml
+++ b/tree/kubescape/default-rules.yaml
@@ -14,14 +14,46 @@ spec:
         ruleExpression:
           - eventType: exec
             expression: >-
-              !ap.was_executed(event.containerId,
-              parse.get_exec_path(event.args, event.comm))
+              !cp.was_executed(event.containerId,
+              parse.get_exec_path(event.args, event.comm, event.exepath))
         uniqueId: event.comm + '_' + event.exepath
       id: R0001
       isTriggerAlert: true
       mitreTactic: TA0002
       mitreTechnique: T1059
       name: Unexpected process launched
+      profileDependency: 0
+      severity: 1
+      supportPolicy: false
+      tags:
+        - anomaly
+        - process
+        - exec
+        - applicationprofile
+    - description: >-
+        Process path is allowed by profile but argument vector does not match
+        any profile entry's arg pattern (literal or wildcard ⋯/*)
+      enabled: true
+      expressions:
+        message: >-
+          'Unexpected process arguments: ' + event.comm + ' with PID ' +
+          string(event.pid)
+        ruleExpression:
+          - eventType: exec
+            expression: >-
+              cp.was_executed(event.containerId,
+              parse.get_exec_path(event.args, event.comm, event.exepath)) &&
+              !cp.was_executed_with_args(event.containerId,
+              parse.get_exec_path(event.args, event.comm, event.exepath),
+              event.args)
+        uniqueId: >-
+          event.comm + '_' + parse.get_exec_path(event.args, event.comm,
+          event.exepath)
+      id: R0040
+      isTriggerAlert: true
+      mitreTactic: TA0002
+      mitreTechnique: T1059
+      name: Unexpected process arguments
       profileDependency: 0
       severity: 1
       supportPolicy: false
@@ -39,7 +71,7 @@ spec:
         ruleExpression:
           - eventType: open
             expression:  >-
-              !ap.was_path_opened(event.containerId, event.path)
+              !cp.was_path_opened(event.containerId, event.path)
         uniqueId: event.comm + '_' + event.path
       id: R0002
       isTriggerAlert: true
@@ -64,7 +96,7 @@ spec:
           + string(event.pid)
         ruleExpression:
           - eventType: syscall
-            expression: '!ap.was_syscall_used(event.containerId, event.syscallName)'
+            expression: '!cp.was_syscall_used(event.containerId, event.syscallName)'
         uniqueId: event.syscallName
       id: R0003
       isTriggerAlert: false
@@ -88,7 +120,7 @@ spec:
           event.syscallName + ' with PID ' + string(event.pid)
         ruleExpression:
           - eventType: capabilities
-            expression: '!ap.was_capability_used(event.containerId, event.capName)'
+            expression: '!cp.was_capability_used(event.containerId, event.capName)'
         uniqueId: event.comm + '_' + event.capName
       id: R0004
       isTriggerAlert: false
@@ -114,7 +146,7 @@ spec:
           - eventType: dns
             expression: >-
               !event.name.endsWith('.svc.cluster.local.') &&
-              !nn.is_domain_in_egress(event.containerId, event.name)
+              !cp.is_domain_in_egress(event.containerId, event.name)
         uniqueId: event.comm + '_' + event.name
       id: R0005
       isTriggerAlert: true
@@ -142,7 +174,7 @@ spec:
                (event.path.startsWith('/var/run/secrets/kubernetes.io/serviceaccount') && event.path.endsWith('/token')) ||
                (event.path.startsWith('/run/secrets/eks.amazonaws.com/serviceaccount') && event.path.endsWith('/token')) ||
                (event.path.startsWith('/var/run/secrets/eks.amazonaws.com/serviceaccount') && event.path.endsWith('/token'))) &&
-              !ap.was_path_opened_with_suffix(event.containerId, '/token')
+              !cp.was_path_opened_with_suffix(event.containerId, '/token')
         uniqueId: event.comm
       id: R0006
       isTriggerAlert: true
@@ -151,7 +183,7 @@ spec:
       name: Unexpected service account token access
       profileDependency: 0
       severity: 5
-      supportPolicy: false
+      supportPolicy: true
       tags:
         - anomaly
         - serviceaccount
@@ -167,13 +199,13 @@ spec:
           - eventType: exec
             expression: >-
               (event.comm == 'kubectl' || event.exepath.endsWith('/kubectl')) &&
-              !ap.was_executed(event.containerId,
-              parse.get_exec_path(event.args, event.comm))
+              !cp.was_executed(event.containerId,
+              parse.get_exec_path(event.args, event.comm, event.exepath))
           - eventType: network
             expression: >-
               event.pktType == 'OUTGOING' &&
               k8s.is_api_server_address(event.dstAddr) &&
-              !nn.was_address_in_egress(event.containerId, event.dstAddr)
+              !cp.was_address_in_egress(event.containerId, event.dstAddr)
         uniqueId: >-
           eventType == 'exec' ? 'exec_' + event.comm : 'network_' +
           event.dstAddr
@@ -201,7 +233,7 @@ spec:
             expression: >
               event.path.startsWith('/proc/') && 
               event.path.endsWith('/environ') &&
-              !ap.was_path_opened_with_suffix(event.containerId, '/environ')
+              !cp.was_path_opened_with_suffix(event.containerId, '/environ')
         uniqueId: event.comm + '_' + event.path
       id: R0008
       isTriggerAlert: true
@@ -225,7 +257,7 @@ spec:
         ruleExpression:
           - eventType: bpf
             expression: >-
-              event.cmd == uint(5) && !ap.was_syscall_used(event.containerId,
+              event.cmd == uint(5) && !cp.was_syscall_used(event.containerId,
               'bpf')
         uniqueId: event.comm + '_' + 'bpf' + '_' + string(event.cmd)
       id: R0009
@@ -250,7 +282,7 @@ spec:
           - eventType: open
             expression: >-
               event.path.startsWith('/etc/shadow') &&
-              !ap.was_path_opened(event.containerId, event.path)
+              !cp.was_path_opened(event.containerId, event.path)
         uniqueId: event.comm + '_' + event.path
       id: R0010
       isTriggerAlert: true
@@ -276,14 +308,46 @@ spec:
         ruleExpression:
           - eventType: network
             expression: >-
-              event.pktType == 'OUTGOING' && !net.is_private_ip(event.dstAddr)
-              && !nn.was_address_in_egress(event.containerId, event.dstAddr)
+              event.pktType == 'OUTGOING'
+              && !event.dstAddr.startsWith('127.')
+              && !cp.was_address_in_egress(event.containerId, event.dstAddr)
+              && !cp.was_selector_in_egress(event.containerId, event.dstNamespace, event.dstPodLabels)
         uniqueId: event.dstAddr + '_' + string(event.dstPort) + '_' + event.proto
       id: R0011
       isTriggerAlert: true
       mitreTactic: TA0010
       mitreTechnique: T1041
       name: Unexpected Egress Network Traffic
+      profileDependency: 0
+      severity: 5
+      supportPolicy: false
+      tags:
+        - whitelisted
+        - network
+        - anomaly
+        - networkprofile
+    - description: >-
+        Detecting unexpected ingress network traffic — an inbound connection whose
+        peer is not whitelisted by the application profile ingress.
+      enabled: true
+      expressions:
+        message: >-
+          'Unexpected ingress network communication from: ' + event.dstAddr + ':' +
+          string(event.dstPort) + ' using ' + event.proto + ' to: ' +
+          event.containerName
+        ruleExpression:
+          - eventType: network
+            expression: >-
+              event.pktType == 'HOST'
+              && !event.dstAddr.startsWith('127.')
+              && !cp.was_address_in_ingress(event.containerId, event.dstAddr)
+              && !cp.was_selector_in_ingress(event.containerId, event.dstNamespace, event.dstPodLabels)
+        uniqueId: event.dstAddr + '_' + string(event.dstPort) + '_' + event.proto
+      id: R0012
+      isTriggerAlert: true
+      mitreTactic: TA0011
+      mitreTechnique: T1071
+      name: Unexpected Ingress Network Traffic
       profileDependency: 0
       severity: 5
       supportPolicy: false
@@ -330,8 +394,8 @@ spec:
             expression: >
               (event.upperlayer == true ||
                event.pupperlayer == true) &&
-              !ap.was_executed(event.containerId,
-              parse.get_exec_path(event.args, event.comm))
+              !cp.was_executed(event.containerId,
+              parse.get_exec_path(event.args, event.comm, event.exepath))
         uniqueId: event.comm + '_' + event.exepath + '_' + event.pcomm
       id: R1001
       isTriggerAlert: true
@@ -383,7 +447,7 @@ spec:
             expression: >-
               dyn(event.srcPort) >= 32768 && dyn(event.srcPort) <= 60999 &&
               !(dyn(event.dstPort) in [22, 2022]) &&
-              !nn.was_address_in_egress(event.containerId, event.dstIp)
+              !cp.was_address_in_egress(event.containerId, event.dstIp)
         uniqueId: event.comm + '_' + event.dstIp + '_' + string(dyn(event.dstPort))
       id: R1003
       isTriggerAlert: true
@@ -406,11 +470,11 @@ spec:
         ruleExpression:
           - eventType: exec
             expression: >-
-              !ap.was_executed(event.containerId,
-              parse.get_exec_path(event.args, event.comm)) &&
+              !cp.was_executed(event.containerId,
+              parse.get_exec_path(event.args, event.comm, event.exepath)) &&
               k8s.get_container_mount_paths(event.namespace, event.podName,
               event.containerName).exists(mount, event.exepath.startsWith(mount)
-              || parse.get_exec_path(event.args, event.comm).startsWith(mount))
+              || parse.get_exec_path(event.args, event.comm, event.exepath).startsWith(mount))
         uniqueId: event.comm
       id: R1004
       isTriggerAlert: true
@@ -460,7 +524,7 @@ spec:
         ruleExpression:
           - eventType: unshare
             expression: >-
-              event.pcomm != 'runc' && !ap.was_syscall_used(event.containerId,
+              event.pcomm != 'runc' && !cp.was_syscall_used(event.containerId,
               'unshare')
         uniqueId: event.comm + '_' + 'unshare'
       id: R1006
@@ -577,7 +641,7 @@ spec:
             expression: >-
               event.proto == 'TCP' && event.pktType == 'OUTGOING' &&
               event.dstPort in [3333, 45700] &&
-              !nn.was_address_in_egress(event.containerId, event.dstAddr)
+              !cp.was_address_in_egress(event.containerId, event.dstAddr)
         uniqueId: event.comm + '_' + string(event.dstPort)
       id: R1009
       isTriggerAlert: false
@@ -604,7 +668,7 @@ spec:
             expression: >-
               (event.oldPath.startsWith('/etc/shadow') ||
               event.oldPath.startsWith('/etc/sudoers')) &&
-              !ap.was_path_opened(event.containerId, event.oldPath)
+              !cp.was_path_opened(event.containerId, event.oldPath)
         uniqueId: event.comm + '_' + event.oldPath
       id: R1010
       isTriggerAlert: true
@@ -659,7 +723,7 @@ spec:
             expression: >-
               (event.oldPath.startsWith('/etc/shadow') ||
               event.oldPath.startsWith('/etc/sudoers')) &&
-              !ap.was_path_opened(event.containerId, event.oldPath)
+              !cp.was_path_opened(event.containerId, event.oldPath)
         uniqueId: event.comm + '_' + event.oldPath
       id: R1012
       isTriggerAlert: true
@@ -744,3 +808,48 @@ spec:
         - tls
         - exec
         - container_administration_command
+    - description: >-
+        Detects when a previously signed ApplicationProfile or
+        NetworkNeighborhood has been tampered with (signature no longer
+        valid).
+      enabled: true
+      expressions:
+        message: "'Signed profile tampered'"
+        uniqueId: "'R1016'"
+        ruleExpression: []
+      id: R1016
+      isTriggerAlert: false
+      mitreTactic: TA0005
+      mitreTechnique: T1565
+      name: Signed profile tampered
+      profileDependency: 2
+      severity: 10
+      supportPolicy: false
+      tags:
+        - integrity
+        - signature
+        - tamper
+    - description: >-
+        Detects exec operations on pods via the Kubernetes admission webhook
+        (PodExecOptions CONNECT).
+      enabled: true
+      expressions:
+        message: >-
+          'Exec to pod: ' + event.Name + ' in namespace ' + event.Namespace +
+          ' by ' + event.UserInfo.Username
+        ruleExpression:
+          - eventType: k8s-admission
+            expression: 'event.Kind == "PodExecOptions"'
+        uniqueId: event.Namespace + '/' + event.Name
+      id: R2000
+      isTriggerAlert: true
+      mitreTactic: TA0002
+      mitreTechnique: T1609
+      name: Exec to pod
+      profileDependency: 2
+      severity: 8
+      supportPolicy: false
+      tags:
+        - context:kubernetes
+        - admission
+        - exec

--- a/tree/kubescape/rule-alert-binding.yaml
+++ b/tree/kubescape/rule-alert-binding.yaml
@@ -1,69 +1,46 @@
-# soc-owned RuntimeRuleAlertBinding.
-#
-# With alertCRD.installDefault:false (tree/kubescape/values.yaml) the kubescape
-# helm chart no longer ships its own all-rules-all-pods binding, so soc supplies
-# it here. This binds the runtime rules to every workload namespace (the NotIn
-# list mirrors values.yaml excludeNamespaces). Whether a bound rule actually
-# fires is still gated by its `enabled` flag in default-rules.yaml
-# (R0002 on, R0003 off, R0011 on).
-#
-# "Syscalls Anomalies in container" (R0003) is intentionally NOT bound here —
-# we are not monitoring syscalls (it emits pid-less PID-0 events that AE cannot
-# attribute; disabled in default-rules.yaml too).
 apiVersion: kubescape.io/v1
 kind: RuntimeRuleAlertBinding
 metadata:
   name: all-rules-all-pods
-  namespace: honey
-  labels:
-    kubescape.io/ignore: "true"
-    tier: ks-control-plane
 spec:
   namespaceSelector:
+  # exclude K8s system namespaces
     matchExpressions:
-      - key: kubernetes.io/metadata.name
-        operator: NotIn
+      - key: "kubernetes.io/metadata.name"
+        operator: "NotIn"
         values:
-          - kubescape
-          - kube-system
-          - kube-flannel
-          - ingress-nginx
-          - olm
-          - px-operator
-          - honey
-          - pl
-          - clickhouse
-          - kube-public
-          - kube-node-lease
-          - local-path-storage
-          - gmp-system
-          - gmp-public
-          - storm
-          - lightening
-          - cert-manager
+        - "kube-system"
+        - "kube-public"
+        - "kube-node-lease"
+        - "kubeconfig"
   rules:
-    - ruleName: Unexpected process launched
-    - ruleName: Files Access Anomalies in container
-    - ruleName: Linux Capabilities Anomalies in container
-    - ruleName: DNS Anomalies in container
-    - ruleName: Unexpected service account token access
-    - ruleName: Workload uses Kubernetes API unexpectedly
-    - ruleName: Process executed from malicious source
-    - ruleName: Process tries to load a kernel module
-    - ruleName: Drifted process executed
-    - ruleName: Disallowed ssh connection
-    - ruleName: Fileless execution detected
-    - ruleName: Crypto miner launched
-    - ruleName: Process executed from mount
-    - ruleName: Crypto Mining Related Port Communication
-    - ruleName: Crypto Mining Domain Communication
-    - ruleName: Read Environment Variables from procfs
-    - ruleName: eBPF Program Load
-    - ruleName: Soft link created over sensitive file
-    - ruleName: Unexpected Sensitive File Access
-    - ruleName: Hard link created over sensitive file
-    - ruleName: Exec to pod
-    - ruleName: Port forward
-    - ruleName: Unexpected Egress Network Traffic
-    - ruleName: Malicious Ptrace Usage
-    - ruleName: Unexpected io_uring Operation Detected
+    - ruleName: "Unexpected process launched"
+    - ruleName: "Unexpected process arguments"
+    - ruleName: "Files Access Anomalies in container"
+    - ruleName: "Syscalls Anomalies in container"
+    - ruleName: "Linux Capabilities Anomalies in container"
+    - ruleName: "DNS Anomalies in container"
+    - ruleName: "Unexpected service account token access"
+    - ruleName: "Workload uses Kubernetes API unexpectedly"
+    - ruleName: "Process executed from malicious source"
+    - ruleName: "Process tries to load a kernel module"
+    - ruleName: "Drifted process executed"
+    - ruleName: "Disallowed ssh connection"
+    - ruleName: "Fileless execution detected"
+    - ruleName: "Crypto miner launched"
+    - ruleName: "Process executed from mount"
+    - ruleName: "Crypto Mining Related Port Communication"
+    - ruleName: "Crypto Mining Domain Communication"
+    - ruleName: "Read Environment Variables from procfs"
+    - ruleName: "eBPF Program Load"
+    - ruleName: "Soft link created over sensitive file"
+    - ruleName: "Unexpected Sensitive File Access"
+    - ruleName: "Hard link created over sensitive file"
+    - ruleName: "Exec to pod"
+    - ruleName: "Port forward"
+    - ruleName: "Unexpected Egress Network Traffic"
+    - ruleName: "Unexpected Ingress Network Traffic"
+    - ruleName: "Malicious Ptrace Usage"
+    - ruleName: "Unexpected io_uring Operation Detected"
+    - ruleName: "Kubelet TLS Exec Request Detected"
+    - ruleName: "Signed profile tampered"

--- a/tree/kubescape/rule-alert-binding.yaml
+++ b/tree/kubescape/rule-alert-binding.yaml
@@ -4,7 +4,9 @@ metadata:
   name: all-rules-all-pods
 spec:
   namespaceSelector:
-  # exclude K8s system namespaces
+  # exclude K8s system namespaces AND the soc/pixie own-stack namespaces, so the
+  # detection firehose never lands on our own pods (saturates the PEM). Mirrors
+  # values.excludeNamespaces. The redis (target) ns is intentionally NOT here.
     matchExpressions:
       - key: "kubernetes.io/metadata.name"
         operator: "NotIn"
@@ -13,6 +15,20 @@ spec:
         - "kube-public"
         - "kube-node-lease"
         - "kubeconfig"
+        - "kubescape"
+        - "kube-flannel"
+        - "ingress-nginx"
+        - "olm"
+        - "px-operator"
+        - "honey"
+        - "pl"
+        - "clickhouse"
+        - "local-path-storage"
+        - "gmp-system"
+        - "gmp-public"
+        - "storm"
+        - "lightening"
+        - "cert-manager"
   rules:
     - ruleName: "Unexpected process launched"
     - ruleName: "Unexpected process arguments"

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -1,16 +1,18 @@
 storage:
   image:
     repository: ghcr.io/k8sstormcenter/storage
-    tag: "sbob-rc4"
-
+    tag: sbob-rc5s
 nodeAgent:
   image:
     repository: ghcr.io/k8sstormcenter/node-agent
-    tag: "sbob-rc4"
+    tag: sbob-rc5s-celnet@sha256:dc4e66680df35dfb4d747544358b7fca906434a78f40ad3b573855935788b6f2
+    pullPolicy: Always
   config:
+    alertManagerExporterUrls:
+      - alertmanager.honey.svc.cluster.local:9093
     maxLearningPeriod: 2m
-    learningPeriod: 2m 
-    updatePeriod: 10000m 
+    learningPeriod: 2m
+    updatePeriod: 10000m
     ruleCooldown:
       ruleCooldownDuration: 0h
       ruleCooldownAfterCount: 1000000000
@@ -18,20 +20,16 @@ nodeAgent:
       ruleCooldownMaxSize: 20000
 capabilities:
   runtimeDetection: enable
-  # networkEventsStreaming stays DISABLED on purpose: the rule engine receives
-  # network+DNS events directly (node-agent container_watcher.go), independent
-  # of the raw network-stream export. Enabling it only drives the httpExporter
-  # (empty url -> "unsupported protocol scheme" dead error). See bob #127/#140 +
-  # memory log4j-network-detection-chain. R0011/R0005 fire without it.
-  networkEventsStreaming: disable
+  configurationScan: disable
+  nodeScan: disable
+  nodeSbomGeneration: disable
+  vulnerabilityScan: disable
+  relevancy: disable
+  admissionController: disable
+  networkEventsStreaming: enable
 alertCRD:
-  # installDefault:false -> the helm chart does NOT create its own default-rules
-  # Rules object nor the all-rules-all-pods binding. soc owns both via rawYaml
-  # (default-rules.yaml + rule-alert-binding.yaml) so our enabled flags
-  # (R0002 on, R0003 off, R0011 on) win deterministically instead of losing the
-  # dual-ownership race to the chart's helm-managed defaults.
-  installDefault: false
+  installDefault: true
   scopeClustered: true
 clusterName: bobexample
 ksNamespace: honey
-excludeNamespaces: "kubescape,kube-system,kube-public,kube-node-lease,local-path-storage,gmp-system,gmp-public,storm,lightening,cert-manager,kube-flannel,ingress-nginx,olm,px-operator,honey,pl,clickhouse"
+excludeNamespaces: "kubescape,kube-system,kube-public,kube-node-lease,local-path-storage,gmp-system,gmp-public,storm,lightening,cert-manager,kube-flannel,ingress-nginx,olm,px-operator,honey,pl,clickhouse,chain-loadgen"

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -28,7 +28,11 @@ capabilities:
   admissionController: disable
   networkEventsStreaming: enable
 alertCRD:
-  installDefault: true
+  # false: soc deploys via skaffold (unordered helm/kubectl apply), so the chart's
+  # own upstream ap.*/nn.* default rules would race and WIN over soc's cp.* rawYaml
+  # rules against the new cp.* node-agent -> "undeclared reference to 'ap'" and zero
+  # detections. soc owns default-rules.yaml + rule-alert-binding.yaml via rawYaml.
+  installDefault: false
   scopeClustered: true
 clusterName: bobexample
 ksNamespace: honey

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -26,7 +26,11 @@ capabilities:
   vulnerabilityScan: disable
   relevancy: disable
   admissionController: disable
-  networkEventsStreaming: enable
+  # disable: the rule engine receives network+DNS events directly (node-agent
+  # container_watcher), so R0005/R0011 fire without it. Enabling only spins up an
+  # http exporter with no URL -> "InitExporters: URL is required" init failure on
+  # every node. soc has no network-stream sink, so keep it off for clean logs.
+  networkEventsStreaming: disable
 alertCRD:
   # false: soc deploys via skaffold (unordered helm/kubectl apply), so the chart's
   # own upstream ap.*/nn.* default rules would race and WIN over soc's cp.* rawYaml

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -26,11 +26,13 @@ capabilities:
   vulnerabilityScan: disable
   relevancy: disable
   admissionController: disable
-  # disable: the rule engine receives network+DNS events directly (node-agent
-  # container_watcher), so R0005/R0011 fire without it. Enabling only spins up an
-  # http exporter with no URL -> "InitExporters: URL is required" init failure on
-  # every node. soc has no network-stream sink, so keep it off for clean logs.
-  networkEventsStreaming: disable
+  # enable is REQUIRED on the rc5s-celnet node-agent: it drives DNS event capture,
+  # so R0005 (DNS anomalies) only fires with it on (R0011 egress works either way,
+  # via networkService). Cost: node-agent logs a one-time "InitExporters: http
+  # exporter URL is required" warning (the stream's http sink has no URL, since soc
+  # has no network-stream endpoint) — benign, detection is unaffected. Verified on
+  # rig 6a749a2b: disable => R0005 stops firing; enable => R0005 fires. Keep enable.
+  networkEventsStreaming: enable
 alertCRD:
   # false: soc deploys via skaffold (unordered helm/kubectl apply), so the chart's
   # own upstream ap.*/nn.* default rules would race and WIN over soc's cp.* rawYaml

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -26,13 +26,15 @@ capabilities:
   vulnerabilityScan: disable
   relevancy: disable
   admissionController: disable
-  # enable is REQUIRED on the rc5s-celnet node-agent: it drives DNS event capture,
-  # so R0005 (DNS anomalies) only fires with it on (R0011 egress works either way,
-  # via networkService). Cost: node-agent logs a one-time "InitExporters: http
-  # exporter URL is required" warning (the stream's http sink has no URL, since soc
-  # has no network-stream endpoint) — benign, detection is unaffected. Verified on
-  # rig 6a749a2b: disable => R0005 stops firing; enable => R0005 fires. Keep enable.
-  networkEventsStreaming: enable
+  # disable: soc runs OFFLINE (no kubescape cloud backend, .Values.server empty), so
+  # the operator renders networkStreamingEnabled=FALSE no matter what this says — it
+  # even emits a capabilityWarning to that effect. So this is a NO-OP for detection
+  # (DNS/network events reach the rule engine via the always-on paths; R0005/R0011
+  # fire regardless). Leaving it "enable" only makes node-agent try to init a stream
+  # http exporter with no URL -> "InitExporters: URL is required" warning every boot.
+  # disable stops that useless init and keeps the node-agent log clean. Verified on
+  # rig 6a749a2b via operator regen + full bobctl attack.
+  networkEventsStreaming: disable
 alertCRD:
   # false: soc deploys via skaffold (unordered helm/kubectl apply), so the chart's
   # own upstream ap.*/nn.* default rules would race and WIN over soc's cp.* rawYaml


### PR DESCRIPTION
Verbatim sync of `tree/kubescape/{values,default-rules,rule-alert-binding}.yaml` from **bob main** (`kubescape/{values,default-rules,default-rule-binding}.yaml`) so soc stops drifting from the maintained source.

**Images (the upgrade):**
- node-agent `sbob-rc4` → `sbob-rc5s-celnet@sha256:dc4e6668…` (pinned digest, `pullPolicy: Always`)
- storage `sbob-rc4` → `sbob-rc5s`

**Rules:** new rule-engine API (`cp.*` / 3-arg `get_exec_path`) that matches the new node-agent, plus new rules **R0040** (unexpected process args), **R0012** (unexpected ingress), **R1016** (signed-profile tamper), **R2000** (exec-to-pod).

**Binding:** synced to bob’s `default-rule-binding`, kept under the filename `rule-alert-binding.yaml` so the `soc-kubescape` skaffold `rawYaml` reference is unchanged.

**Own-namespace exclusion** now travels with `values.excludeNamespaces` (honey, pl, clickhouse, chain-loadgen, …), which is how bob keeps our own stack out of scope.

Cooldown block is unchanged (bob main = `duration 0h`, `afterCount 1000000000`, `maxSize 20000`) — the large `afterCount` is what gives effectively zero cooldown.