### PR TITLE
kubescape: node-agent rc-sofia-port0fix + storage v0.0.303 (opens_gadget fix)

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -66,9 +66,7 @@ manifests:
   helm:
     releases:
       - name: kubescape
-        repo: https://kubescape.github.io/helm-charts/
-        remoteChart: kubescape-operator
-        version: 1.40.3
+        remoteChart: https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.40.3-node-agent-rc-sofia/kubescape-operator-1.40.3-node-agent-rc-sofia.tgz
         namespace: honey
         createNamespace: true
         valuesFiles:

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -1,11 +1,11 @@
 storage:
   image:
     repository: ghcr.io/k8sstormcenter/storage
-    tag: sbob-rc5s
+    tag: v0.0.303
 nodeAgent:
   image:
     repository: ghcr.io/k8sstormcenter/node-agent
-    tag: sbob-rc5s-celnet@sha256:dc4e66680df35dfb4d747544358b7fca906434a78f40ad3b573855935788b6f2
+    tag: rc-sofia-port0fix
     pullPolicy: Always
   config:
     alertManagerExporterUrls:


### PR DESCRIPTION
Syncs soc's kubescape config to bob@18a005f for the **opens_gadget fix**.

**Problem:** after a container has been up a while, liveness/readiness probe execs (`ping_liveness_local.sh` → `redis-cli` → `bash`/`awk`) were reported by node-agent with the container overlay path `/<containerID>/rootfs/<path>` instead of the in-container path. Those never match the SBoB's in-container paths, so they fired spurious **R0002 "Unexpected file access"** — polluting the order set with `/…/rootfs/…` noise.

**Fix:** node-agent `rc-sofia-port0fix` (from bob `18a005f`).

**Changes (fix-only, signing OFF):**
- `tree/kubescape/values.yaml`: node-agent `sbob-rc5s-celnet` → `rc-sofia-port0fix`; storage `sbob-rc5s` → `v0.0.303`.
- `skaffold.yaml` (`soc-kubescape`): chart → forked `kubescape-operator-1.40.3-node-agent-rc-sofia` (carries the fixed node-agent).
- **Not** adopting bob's `bundleSigning` block — soc doesn't wire signed default-rules / trust configmap, and enabling it would break unsigned-SBoB binding.
- `default-rules.yaml` unchanged; `rule-alert-binding.yaml` kept (retains the soc/pixie namespace exclusions bob's lacks).