### PR TITLE
perf(clickhouse): query governors + right-size CH to the 4-vCPU node

### DIFF
--- a/tree/clickhouse-lab/installation.yaml
+++ b/tree/clickhouse-lab/installation.yaml
@@ -21,6 +21,8 @@ spec:
       background_pool_size: "16"
       query_log/flush_interval_milliseconds: "5000"
       skip_check_for_incorrect_settings: "1"
+      # bound total in-flight queries (default 100) so a burst can't peg the node
+      max_concurrent_queries: "12"
 
     profiles:
       # Default profile: user-level session settings
@@ -28,9 +30,16 @@ spec:
       default/async_insert_max_data_size: "10485760"
       default/async_insert_busy_timeout_ms: "200"
 
-      # Analyst: read-only, no DDL, no settings changes
+      # Analyst: read-only, no DDL, no settings changes.
+      # Governors on the UI/read path: without max_execution_time a query the UI
+      # cancels client-side keeps running server-side forever; repeated opens stack
+      # them until CPU saturates and the node starves (exec-into-CH then SIGILLs).
       forensic_analyst/readonly: "2"
       forensic_analyst/allow_ddl: "0"
+      forensic_analyst/max_execution_time: "30"
+      forensic_analyst/max_threads: "2"
+      forensic_analyst/max_concurrent_queries_for_user: "4"
+      forensic_analyst/max_memory_usage: "4000000000"
 
       # Ingest: INSERT allowed, no DELETE/ALTER/DDL.
       # Async insert: CH accumulates rows in RAM and flushes in bulk,
@@ -73,13 +82,15 @@ spec:
         containers:
         - name: clickhouse
           image: clickhouse/clickhouse-server:24.8
+          # sized to the 4-vCPU / 8GiB node: cpu limit 3 (not 8) leaves a core for
+          # vizier-pem/dx/kubelet so CH can't starve the whole node under load
           resources:
             requests:
-              memory: 512Mi
-              cpu: 250m
+              memory: 2Gi
+              cpu: "1"
             limits:
-              memory: 16Gi
-              cpu: 8
+              memory: 6Gi
+              cpu: "3"
 
     volumeClaimTemplates:
     - name: data-volume


### PR DESCRIPTION
## Problem
The evidence-graph UI wedges: clickhouse-server pegs the node's CPU, queries stop returning, and `kubectl exec` into the CH pod starts failing with SIGILL (exit 132) under starvation — while execs into other pods on the same node succeed.

## RCA
The `forensic_analyst` (UI/read) profile ships with **no query governors** — everything at CH 24.8 defaults:
- `max_execution_time = 0` → a query the UI cancels client-side **keeps running server-side forever**. Hitting the UI repeatedly **stacks** full-scans that never die → CPU saturates → node starves → exec-into-CH SIGILLs. Self-inflicted, no auto-heal.
- `max_threads = auto = 4` → each scan grabs all 4 cores.
- `max_concurrent_queries = 100` → unbounded pile-up.
- pod **CPU limit = 8 on a 4-vCPU node** → CH can consume the entire node, leaving nothing for vizier-pem / dx / kubelet.

## Validated (4-vCPU rig, 325k-row `dx_ord__http_events` at prod scale)
| Test | Result |
|---|---|
| single JOIN-view scan, native | **92 ms** — CH compute is *not* the bottleneck |
| no governor, client detaches mid-query | **runs forever server-side** (alive past 4.1 s) |
| `max_execution_time=5` | **TIMEOUT_EXCEEDED, killed at 5 s** |
| 15 concurrent scans: default → `max_threads=2` | 2153 ms → 1781 ms |

## Change (`tree/clickhouse-lab/installation.yaml`, applied on first soc skaffold)
- `forensic_analyst`: `max_execution_time=30`, `max_threads=2`, `max_concurrent_queries_for_user=4`, `max_memory_usage=4GB`
- server-wide `max_concurrent_queries=12` (was default 100)
- `background_pool_size` 16 → 6 (merge threads vs query CPU on 4 cores)
- pod CPU limit 8 → 3, mem 16Gi → 6Gi, requests 250m/512Mi → 1/2Gi

The governors bound the blast radius so one flood can't wedge the box and runaway queries self-terminate. The underlying scan cost (data volume + px pulling whole views) is addressed separately (SBoB FP reduction).