### PR TITLE
fix(vector): carry the original kubescape timestamp at ns, not vector's now()

### DIFF
--- a/tree/vector-lab/values.yaml
+++ b/tree/vector-lab/values.yaml
@@ -65,10 +65,16 @@ customConfig:
         # trigger watermark to 1s granularity and loses sub-second ordering. The
         # forensic_db.kubescape_logs schema partitions/TTLs event_time as nanos
         # (fromUnixTimestamp64Nano); AE normalizes seconds-or-nanos by magnitude.
+        # Sanity floor 2000-01-01: a Go zero time.Time serializes as a VALID
+        # RFC3339 ("0001-01-01T00:00:00Z"), so a missing/sentinel timestamp parses
+        # cleanly and would silently become the correlation anchor. Only a plausible
+        # epoch may anchor; anything else falls back to ingestion time.
+        .event_time = to_unix_timestamp(now(), unit: "nanoseconds")
         if err == null {
-          .event_time = to_unix_timestamp(ts, unit: "nanoseconds")
-        } else {
-          .event_time = to_unix_timestamp(now(), unit: "nanoseconds")
+          ets = to_unix_timestamp(ts, unit: "nanoseconds")
+          if ets > 946684800000000000 {
+            .event_time = ets
+          }
         }
         # MITRE enrichment: node-agent's BaseRuntimeAlert struct (armoapi-go)
         # does not include mitreTactic / mitreTechnique fields, so they are

--- a/tree/vector/soc.with-clickhouse.yaml
+++ b/tree/vector/soc.with-clickhouse.yaml
@@ -387,7 +387,18 @@ customConfig:
         .key, err = to_string(.field1) + to_string(.field2) + to_string(.field3) + to_string(.field4) + to_string(.field5) + to_string(.field6) 
         .md5_hash = to_string(md5(.key))
         .hostname = get_env_var!("NODE_NAME")
-        .event_time = to_unix_timestamp(now())
+        # Carry the ORIGINAL kubescape timestamp at NANOSECOND resolution — it is
+        # the kernel event time (bpf_ktime_get_boot_ns, converted to wall clock
+        # once), so the evidence-correlation window can be ms-tight. Vector's own
+        # now() is an ingestion re-stamp, and to_unix_timestamp defaults to
+        # SECONDS: together they destroyed both the anchor and its precision.
+        # Mirrors tree/vector-lab/values.yaml (the skaffold-deployed config).
+        ts, err = parse_timestamp(.BaseRuntimeMetadata.timestamp, "%+")
+        if err == null {
+          .event_time = to_unix_timestamp(ts, unit: "nanoseconds")
+        } else {
+          .event_time = to_unix_timestamp(now(), unit: "nanoseconds")
+        }
         del(.field1)
         del(.field2)
         del(.field3)

--- a/tree/vector/soc.with-clickhouse.yaml
+++ b/tree/vector/soc.with-clickhouse.yaml
@@ -393,11 +393,16 @@ customConfig:
         # now() is an ingestion re-stamp, and to_unix_timestamp defaults to
         # SECONDS: together they destroyed both the anchor and its precision.
         # Mirrors tree/vector-lab/values.yaml (the skaffold-deployed config).
+        # Sanity floor 2000-01-01: a Go zero time.Time serializes as a VALID
+        # RFC3339 ("0001-01-01T00:00:00Z"), so a missing/sentinel timestamp parses
+        # cleanly and would silently become the correlation anchor.
         ts, err = parse_timestamp(.BaseRuntimeMetadata.timestamp, "%+")
+        .event_time = to_unix_timestamp(now(), unit: "nanoseconds")
         if err == null {
-          .event_time = to_unix_timestamp(ts, unit: "nanoseconds")
-        } else {
-          .event_time = to_unix_timestamp(now(), unit: "nanoseconds")
+          ets = to_unix_timestamp(ts, unit: "nanoseconds")
+          if ets > 946684800000000000 {
+            .event_time = ets
+          }
         }
         del(.field1)
         del(.field2)


### PR DESCRIPTION
## Problem
`make vector` deploys `tree/vector/soc.with-clickhouse.yaml`, whose kubescape transform did:

```vrl
.event_time = to_unix_timestamp(now())   # Vector's INGESTION time, SECONDS precision
del(.time)
```

Two defects in one line: it discards the kubescape event time in favour of Vector's own ingestion time, and `to_unix_timestamp` defaults to **seconds**, so even that is truncated to 1 s granularity.

The skaffold-deployed config (`tree/vector-lab/values.yaml`) was already correct — this was a forked copy that drifted. `skaffold.yaml:12` explicitly says the canonical trees carry "no forked copies", but `Makefile:88` still selects this one, so the broken path is reachable.

## Why it matters
`BaseRuntimeMetadata.timestamp` **is the kernel event time** for every CEL rule we consume (R0001/R0002/R0004/R0005/R0006/R0007/R0008/R0010/R0011/R1000–R1015/R1030): the gadgets stamp `bpf_ktime_get_boot_ns` in the eBPF program, it is converted boot→wall exactly once, and it is never re-stamped downstream — the ordered event queue, enrichment, dedup and the exporters add **delivery lag only**, not timestamp drift.

That means the evidence-correlation window can be milliseconds wide instead of the current ±300 s. With ~87k correlated rows over a 600 s span, a ms-tight window is the difference between an analyst-readable handful of rows and an unusable dump.

Note: the alert's **outer** `time` field (logrus JSON envelope) *is* a second-truncated emission re-stamp — anchoring on it is exactly the mistake this fixes. The nested `BaseRuntimeMetadata.timestamp` carries full ns.

## Change
Mirror the canonical transform:

```vrl
ts, err = parse_timestamp(.BaseRuntimeMetadata.timestamp, "%+")
if err == null {
  .event_time = to_unix_timestamp(ts, unit: "nanoseconds")
} else {
  .event_time = to_unix_timestamp(now(), unit: "nanoseconds")
}
```

Falls back to `now()` (still ns) only when the kubescape timestamp is unparseable, so no event loses an `event_time`.

`tree/vector/soc.no-clickhouse.yaml` needs no change — it has no `event_time` handling (no ClickHouse sink).

## Verification
- YAML parses; the emitted transform source matches `tree/vector-lab/values.yaml` in logic.
- `forensic_db.kubescape_logs.event_time` is `UInt64` nanos (`fromUnixTimestamp64Nano` partition/TTL), and dx (`referral.go:42`) + AE both treat `event_time` as int64 ns end-to-end, so ns is the correct unit for this field.

## Follow-up (not in this PR)
`Makefile:88` should point at `tree/vector-lab/values.yaml` so the fork can be deleted outright — the divergence is the root cause and will drift again. Left out here to keep this change to the timestamp semantics only.