### PR TITLE
chore(kubescape): net-v2-rc1 images + IPv6-loopback exclusion in R0011/R0012

### DIFF
--- a/tree/kubescape/default-rules.yaml
+++ b/tree/kubescape/default-rules.yaml
@@ -310,7 +310,8 @@ spec:
             expression: >-
               event.pktType == 'OUTGOING'
               && !event.dstAddr.startsWith('127.')
-              && !cp.was_address_in_egress(event.containerId, event.dstAddr)
+              && event.dstAddr != '::1'
+              && !cp.was_address_port_protocol_in_egress(event.containerId, event.dstAddr, event.dstPort, event.proto)
               && !cp.was_selector_in_egress(event.containerId, event.dstNamespace, event.dstPodLabels)
         uniqueId: event.dstAddr + '_' + string(event.dstPort) + '_' + event.proto
       id: R0011
@@ -340,7 +341,8 @@ spec:
             expression: >-
               event.pktType == 'HOST'
               && !event.dstAddr.startsWith('127.')
-              && !cp.was_address_in_ingress(event.containerId, event.dstAddr)
+              && event.dstAddr != '::1'
+              && !cp.was_address_port_protocol_in_ingress(event.containerId, event.dstAddr, event.dstPort, event.proto)
               && !cp.was_selector_in_ingress(event.containerId, event.dstNamespace, event.dstPodLabels)
         uniqueId: event.dstAddr + '_' + string(event.dstPort) + '_' + event.proto
       id: R0012

--- a/tree/kubescape/values.yaml
+++ b/tree/kubescape/values.yaml
@@ -1,11 +1,11 @@
 storage:
   image:
     repository: ghcr.io/k8sstormcenter/storage
-    tag: v0.0.303
+    tag: net-v2-rc1
 nodeAgent:
   image:
     repository: ghcr.io/k8sstormcenter/node-agent
-    tag: rc-sofia-port0fix
+    tag: net-v2-rc1
     pullPolicy: Always
   config:
     alertManagerExporterUrls:


### PR DESCRIPTION
Tracks **bob#208** (`chore/net-v2-rc1`).

## Change
| file | change |
|---|---|
| `tree/kubescape/values.yaml` | storage `v0.0.303` → `net-v2-rc1`; node-agent `rc-sofia-port0fix` → `net-v2-rc1` |
| `tree/kubescape/default-rules.yaml` | R0011/R0012: add `event.dstAddr != '::1'`; `cp.was_address_in_{egress,ingress}` → `cp.was_address_port_protocol_in_{egress,ingress}` |

Rules and images must ship together — the port/proto-aware helper only exists in `net-v2-rc1`. After this, `tree/kubescape/default-rules.yaml` is byte-identical to bob#208's.

## What is deliberately NOT synced
bob's `values.yaml` differs from soc's in two places that are soc-specific and stay as they are:

- `networkEventsStreaming: disable` (bob: `enable`) — soc runs offline with no kubescape cloud backend, so the operator renders `networkStreamingEnabled=false` regardless; `enable` only makes node-agent attempt a stream exporter with no URL and log `InitExporters: URL is required` every boot. Detection is unaffected (DNS/network reach the rule engine via the always-on paths).
- `installDefault: false` (bob: `true`) — soc deploys via skaffold, which applies helm/kubectl unordered. With `true`, the chart's upstream `ap.*`/`nn.*` default rules race soc's `cp.*` rawYaml rules against the cp.* node-agent → `undeclared reference to 'ap'` → **zero detections**. soc owns `default-rules.yaml` + `rule-alert-binding.yaml` via rawYaml.

Copying bob's values.yaml wholesale would break detection on soc; only the image tags are taken.

## Why R0011/R0012 matter here
On rig `6a8c5af1` these are the rules that fire on postgres wire traffic — R0011 `egress … :5432 from pg-client` (78 alerts) and R0012 `ingress … :5432 to postgres` (11). They are the anchors for DB-protocol evidence collection, so the IPv6-loopback false positives they currently raise are directly in the path of that work.

## Verification
- both files parse (`yaml.safe_load`)
- `tree/kubescape/default-rules.yaml` diffs clean against bob#208
- not yet exercised on a rig with `net-v2-rc1` images — that is the next step, and this PR should not merge before that run is green